### PR TITLE
Naive implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ regex = "1.5"
 spectral = "0.6.0"
 ouroboros = "0.14.2"
 rksuid = { path = "../rksuid" }
+derive_more = "0.99.17"
+float_eq = "0.7.0"
+
+[dev-dependencies]
+proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "drain-flow"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0.56"
+fraction = "0.10.0"
+itertools = "0.10.3"
+regex = "1.5"
+spectral = "0.6.0"
+ouroboros = "0.14.2"
+rksuid = { path = "../rksuid" }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# drain-flow
+# Drain Flow
+
+Implementations of [Drain](https://jiemingzhu.github.io/pub/pjhe_icws2017.pdf) starting with an extremely naive single level approach and building towards a hopefully highly efficient implementation using [DifferentialDataflow](https://github.com/TimelyDataflow/differential-dataflow) with arbitrary depth.
+
+## What is drain?
+
+Drain is a technique for parsing and grouping log lines using a fixed depth parse tree. Parsing happens in several stages, see the linked paper for full details but the general idea is that first we run a pass of domain specific regexs to eliminate fields with expected variation (think leading timestamps on a log file which convey nothing about the similarity of log content), then selects a parse tree based on the number of words/tokens in the message, and finally descending into a token tree of arbitrary depth.
+
+At the bottom of the tree is a vector of potential log matches which are the same length and begin with the same N tokens (or matching wildcards). Each match is scored by comparing the token in each position and awarding a point for each match.
+
+The top-scoring message is then evaluated against as score / length > threshold and either added as an example of the existing record or added as a new record. When messages are added as new examples an additional pass is done to find any non-matching tokens and replace them with wildcards.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,68 @@
+pub mod log_group;
+pub mod record;
+
+use anyhow::Error;
+use fraction::{BigInt, Ratio};
+use log_group::LogGroup;
+use record::Record;
+use regex::Regex;
+use std::collections::HashMap;
+
+pub struct SimpleDrain<'a> {
+    pub domain: Vec<Regex>,
+    // NumTokens -> First Token -> List of Log groups
+    base_layer: HashMap<usize, HashMap<String, Vec<LogGroup<'a>>>>,
+    pub threshold: Ratio<BigInt>,
+}
+
+impl<'a> SimpleDrain<'a> {
+    pub fn new(domain: Vec<String>) -> Result<Self, Error> {
+        let patterns = domain
+            .iter()
+            .map(|s| Regex::new(&s))
+            .collect::<Result<Vec<Regex>, regex::Error>>()?;
+        Ok(Self {
+            domain: patterns,
+            base_layer: HashMap::new(),
+            threshold: Ratio::from_float::<f32>(0.5).expect("0.5 converts into a ratio"),
+        })
+    }
+
+    pub fn process_line(mut self, line: &'a str) -> Result<bool, Error> {
+        let mut found_new = false;
+        let new_record = Record::new(line);
+        if let Some(second_layer) = self.base_layer.get_mut(&new_record.len()) {
+            if let Some(log_groups) =
+                second_layer.get_mut(new_record.first().expect("records have first tokens"))
+            {
+                let (score, offset) = log_groups.into_iter().enumerate().fold(
+                    (
+                        0, // best score
+                        0, // index of best score LogGroup
+                    ),
+                    |mut acc, elem| {
+                        let score = new_record.clone().calc_sim_score(&elem.1.event());
+                        if score > acc.0 {
+                            acc = (score, elem.0); // overwrite state with new values
+                        }
+                        acc
+                    },
+                );
+                let score_ratio =
+                    Ratio::<BigInt>::new(BigInt::from(score), BigInt::from(new_record.len()));
+                match score_ratio > self.threshold {
+                    true => {
+                        // add this record's uid to the list of examples for the log group
+                        log_groups[offset].add_example(new_record);
+                        // TODO: do token update pass
+                    }
+                    false => {
+                        log_groups.push(LogGroup::new(new_record));
+                        found_new = true;
+                    }
+                }
+            }
+        }
+        Ok(found_new)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,16 +42,6 @@ impl<'a> SimpleDrain<'a> {
             .first()
             .expect("records have first tokens")
             .to_owned();
-        // let log_groups = self.base_layer
-        //     .entry(length)
-        //     .or_insert_with( || {
-        //         let mut map = HashMap::new();
-        //         map.insert(
-        //             new_record.first().expect("").to_owned(),
-        //             vec![LogGroup::new(new_record.clone())],
-        //         );
-        //         map
-        //     });
         if let Some(second_layer) = self.base_layer.get_mut(&length) {
             if let Some(log_groups) = second_layer.get_mut(&first as &str) {
                 let (score, offset) = log_groups.into_iter().enumerate().fold(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@ pub mod log_group;
 pub mod record;
 
 use anyhow::{anyhow, Error};
-use fraction::{BigInt, Ratio};
+use fraction::{BigInt, FromPrimitive, Ratio};
 use log_group::LogGroup;
 use record::Record;
 use regex::Regex;
@@ -27,6 +27,14 @@ impl<'a> SimpleDrain<'a> {
             base_layer: HashMap::new(),
             threshold: Ratio::from_float::<f32>(0.5).expect("0.5 converts into a ratio"),
         })
+    }
+
+    pub fn set_threshold(&mut self, numerator: u64, denominator: u64) -> Result<(), Error> {
+        let numer = BigInt::from_u64(numerator).ok_or(anyhow!("unable to make numerator from {}", numerator))?;
+        let denom = BigInt::from_u64(denominator).ok_or(anyhow!("unable to make denominator from {}", denominator))?;
+        let new_ratio = Ratio::new(numer, denom);
+        self.threshold = new_ratio;
+        Ok(())
     }
 
     /// Accepts a line of input for processing against existing records
@@ -92,6 +100,13 @@ mod should {
     fn test_new_drain() {
         let drain = SimpleDrain::new(vec![]);
         assert_that(&drain).is_ok();
+    }
+
+    #[test]
+    fn test_set_threshold() {
+        let mut drain = SimpleDrain::new(vec![]).unwrap();
+        let res = drain.set_threshold(100, 200);
+        assert_that(&res).is_ok();
     }
 
     #[test]

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,11 +1,13 @@
-use crate::record::Record;
+use crate::record::{Record, tokens::Token};
 
 #[derive(Clone, Debug)]
 pub struct LogGroup<'a> {
     event: Record<'a>,
     examples: Vec<Record<'a>>,
-    wildcards: Vec<usize>,
+    wildcards: Vec<Wildcard>,
 }
+
+type Wildcard = (usize, Token);
 
 impl<'a> LogGroup<'a> {
     pub fn new(event: Record<'a>) -> Self {
@@ -22,5 +24,12 @@ impl<'a> LogGroup<'a> {
     
     pub fn event(&self) -> &Record<'a> {
         &self.event
+    }
+}
+
+impl Iterator for LogGroup<'_> {
+    type Item = Wildcard;
+    fn next(&mut self) -> Option<Wildcard> {
+        None
     }
 }

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,0 +1,26 @@
+use crate::record::Record;
+
+#[derive(Clone, Debug)]
+pub struct LogGroup<'a> {
+    event: Record<'a>,
+    examples: Vec<Record<'a>>,
+    wildcards: Vec<usize>,
+}
+
+impl<'a> LogGroup<'a> {
+    pub fn new(event: Record<'a>) -> Self {
+        Self {
+            event: event,
+            examples: vec![],
+            wildcards: vec![],
+        }
+    }
+
+    pub fn add_example(&mut self, rec: Record<'a>) {
+        self.examples.push(rec);
+    }
+    
+    pub fn event(&self) -> &Record<'a> {
+        &self.event
+    }
+}

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,0 +1,115 @@
+use itertools::Itertools;
+use rksuid::rksuid;
+
+use crate::log_group::LogGroup;
+
+#[derive(Clone, Debug)]
+pub struct Record<'a> {
+    pub raw_message: &'a str,
+    tokens: Vec<(usize, usize)>,
+    pos: usize,
+    pub uid: rksuid::Ksuid,
+}
+impl<'a> Record<'a> {
+    pub fn new(line: &'a str) -> Self {
+        Self {
+            raw_message: line.clone(),
+            tokens: line
+                .char_indices()
+                .filter(|t| {
+                    (t.0 == 0 && !t.1.is_whitespace()) // The very first char needs special handling
+                        || (t.1.is_whitespace()
+                            && line
+                                .chars()
+                                .clone()
+                                .nth(t.0 - 1)
+                                .and_then(|c| Some(!c.is_whitespace()))
+                                .unwrap())
+                })
+                .map(|t| t.0)
+                .tuple_windows::<(_, _)>()
+                .map(|t| (t.0, t.1))
+                .collect::<Vec<(usize, usize)>>(),
+            pos: 0,
+            uid: rksuid::new(None, None),
+        }
+    }
+
+    pub fn calc_sim_score(self, candidate: &'a LogGroup) -> u64 {
+        let pairs = self
+            .into_iter()
+            .zip(candidate.event().clone().into_iter())
+            .collect::<Vec<(_, _)>>();
+
+        let score = pairs
+            .iter()
+            .filter(|pair| pair.0 == pair.1 || pair.1 == "*")
+            .fold(0_u64, |acc, _pair| acc + 1);
+        score
+    }
+
+    pub fn first(&'a self) -> Option<&'a str> {
+        let (start, end) = self.tokens[0];
+        self.raw_message.get(start..end)
+    }
+
+    pub fn len(&'a self) -> usize {
+        self.tokens.len()
+    }
+}
+impl<'a> Iterator for Record<'a> {
+    type Item = &'a str;
+    fn next(self: &mut Record<'a>) -> Option<Self::Item> {
+        let pos = self.pos;
+        if pos >= self.tokens.len() {
+            return None;
+        }
+
+        let (start, end) = self.tokens[pos];
+        self.pos += 1;
+        self.raw_message.get(start..end)
+    }
+}
+#[cfg(test)]
+mod should {
+    use crate::Record;
+    use spectral::prelude::*;
+    #[test]
+    fn test_record_new() {
+        let input = "Message send failed to remote host: foo.bar.com";
+        let rec = Record::new(input);
+        assert_eq!(input, rec.raw_message);
+    }
+    #[test]
+    fn test_record_calc_sim_score() {
+        let input = "Message send failed to remote host: foo.bar.com";
+        let input2 = "Message send succeeded with flying colors";
+        let rec = Record::new(input);
+        let other = Record::new(input2);
+        let score = rec.calc_sim_score(&other);
+        assert_eq!(score, 2);
+    }
+    #[test]
+    fn test_record_first() {
+        let input = "Message send failed to remote host: foo.bar.com";
+        let rec = Record::new(input);
+        assert_eq!(rec.first(), Some("Message"));
+    }
+    #[test]
+    fn test_record_len() {
+        let input = "Message send failed to remote host: foo.bar.com";
+        let rec = Record::new(input);
+        assert_eq!(rec.len(), 7);
+    }
+
+    #[test]
+    fn test_into_iter() {
+        let input = "Message send failed to remote host: foo.bar.com";
+        let rec = Record::new(input.clone());
+        let tokens = rec.into_iter().collect::<Vec<&str>>();
+        let words = &input
+            .split(|c: char| c.is_whitespace())
+            .collect::<Vec<&str>>();
+        assert_that(&tokens.iter()).contains_all_of(&words.iter());
+    }
+}

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -27,18 +27,19 @@ impl<'a> Record<'a> {
                                 .unwrap())
                 })
                 .map(|t| t.0)
+                .chain(vec![line.len()].into_iter())
                 .tuple_windows::<(_, _)>()
-                .map(|t| (t.0, t.1))
+                .map(|t| (if t.0 == 0 { t.0 } else { t.0 + 1 }, t.1))
                 .collect::<Vec<(usize, usize)>>(),
             pos: 0,
             uid: rksuid::new(None, None),
         }
     }
 
-    pub fn calc_sim_score(self, candidate: &'a LogGroup) -> u64 {
+    pub fn calc_sim_score(self, candidate: &'a Record) -> u64 {
         let pairs = self
             .into_iter()
-            .zip(candidate.event().clone().into_iter())
+            .zip(candidate.clone().into_iter())
             .collect::<Vec<(_, _)>>();
 
         let score = pairs

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,7 +1,8 @@
+pub mod tokens;
+extern crate derive_more;
+
 use itertools::Itertools;
 use rksuid::rksuid;
-
-use crate::log_group::LogGroup;
 
 #[derive(Clone, Debug)]
 pub struct Record<'a> {

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -1,5 +1,4 @@
 use float_eq::float_eq;
-use std::any::TypeId;
 
 #[derive(Debug, Clone)]
 pub enum Token {
@@ -19,30 +18,6 @@ pub enum TypedToken {
     Int(i64),
     /// Token containing a float
     Float(f64),
-}
-
-impl TypedToken {
-    fn is_string(&self) -> bool {
-        match self {
-            TypedToken::String(_) => true,
-            TypedToken::Int(_) => false,
-            TypedToken::Float(_) => false,
-        }
-    }
-    fn is_int(&self) -> bool {
-        match self {
-            TypedToken::String(_) => false,
-            TypedToken::Int(_) => true,
-            TypedToken::Float(_) => false,
-        }
-    }
-    fn is_float(&self) -> bool {
-        match self {
-            TypedToken::String(_) => false,
-            TypedToken::Int(_) => false,
-            TypedToken::Float(_) => true,
-        }
-    }
 }
 
 impl PartialEq for Token {

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -1,0 +1,238 @@
+use float_eq::float_eq;
+use std::any::TypeId;
+
+#[derive(Debug, Clone)]
+pub enum Token {
+    /// Token that matches any other token
+    Wildcard,
+    /// Token that matches any value of the inner type
+    TypedMatch(TypedToken),
+    /// Token containing a typed, non-wildcard value
+    Value(TypedToken),
+}
+
+#[derive(PartialEq, Debug, Clone)]
+pub enum TypedToken {
+    /// Token containing a string with at least 1 non-digit
+    String(String),
+    /// Token containing a whole number only
+    Int(i64),
+    /// Token containing a float
+    Float(f64),
+}
+
+impl TypedToken {
+    fn is_string(&self) -> bool {
+        match self {
+            TypedToken::String(_) => true,
+            TypedToken::Int(_) => false,
+            TypedToken::Float(_) => false,
+        }
+    }
+    fn is_int(&self) -> bool {
+        match self {
+            TypedToken::String(_) => false,
+            TypedToken::Int(_) => true,
+            TypedToken::Float(_) => false,
+        }
+    }
+    fn is_float(&self) -> bool {
+        match self {
+            TypedToken::String(_) => false,
+            TypedToken::Int(_) => false,
+            TypedToken::Float(_) => true,
+        }
+    }
+}
+
+impl PartialEq for Token {
+    fn eq(&self, other: &Self) -> bool {
+        return match self {
+            Token::Wildcard => true,
+            Token::TypedMatch(tm) => match other {
+                Token::Wildcard => true,
+                Token::TypedMatch(otm) => tm == otm,
+                Token::Value(other_val) => match tm {
+                    TypedToken::String(_) => {
+                        if let TypedToken::String(_) = other_val {
+                            return true;
+                        }
+                        false
+                    },
+                    TypedToken::Int(_) => {
+                        if let TypedToken::Int(_) = other_val {
+                            return true;
+                        }
+                        false
+                    },
+                    TypedToken::Float(_) => {
+                        if let TypedToken::Float(_) = other_val {
+                            return true;
+                        }
+                        true
+                    },
+                },
+            },
+            Token::Value(val) => match other {
+                Token::Wildcard => true,
+                Token::TypedMatch(tm) => {
+                    match val {
+                        TypedToken::String(_) => {
+                            if let TypedToken::String(_) = tm {
+                                return true;
+                            }
+                            false 
+                        },
+                        TypedToken::Int(_) => {
+                            if let TypedToken::Int(_) = tm {
+                                return true;
+                            }
+                            false
+                        },
+                        TypedToken::Float(_) => {
+                            if let TypedToken::Float(_) = tm {
+                                return true
+                            }
+                            false
+                        },
+                    }
+                },
+                Token::Value(other_val) => match val {
+                    TypedToken::String(string_val) => {
+                        if let TypedToken::String(other_string) = other_val {
+                            return string_val == other_string;
+                        }
+                        false
+                    }
+                    TypedToken::Int(int_val) => {
+                        if let TypedToken::Int(other_int) = other_val {
+                            return int_val == other_int;
+                        }
+                        false
+                    }
+                    TypedToken::Float(float_val) => {
+                        if let TypedToken::Float(other_float) = other_val {
+                            return float_eq!(float_val, other_float, ulps <= 1);
+                        }
+                        false
+                    }
+                },
+            },
+        };
+    }
+}
+
+impl Eq for Token {}
+
+#[cfg(test)]
+mod should {
+    use crate::record::tokens::{Token, TypedToken};
+    use spectral::prelude::*;
+    use proptest::prelude::*;
+
+    #[test]
+    fn test_wildcard_lhs() {
+        let lhs = Token::Wildcard;
+        let rhs = Token::Value(TypedToken::String("foo".to_string()));
+        assert_that(&lhs).is_equal_to(rhs.clone());
+        assert_that(&rhs).is_equal_to(lhs);
+    }
+
+    proptest! {
+        #[test]
+        fn test_wildcard_matches_any_string(s in "\\PC*") {
+            let wildcard = Token::Wildcard;
+            let val = Token::Value(TypedToken::String(s));
+            assert_that(&wildcard).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(wildcard);
+        }
+
+        #[test]
+        fn test_wildcard_matches_any_int(s in i64::MIN..i64::MAX) {
+            let wildcard = Token::Wildcard;
+            let val = Token::Value(TypedToken::Int(s));
+            assert_that(&wildcard).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(wildcard);
+        }
+
+        #[test]
+        fn test_wildcard_matches_any_positive_float(s in 0f64..f64::MAX) {
+            let wildcard = Token::Wildcard;
+            let val = Token::Value(TypedToken::Float(s));
+            assert_that(&wildcard).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(wildcard);
+        }
+
+        #[test]
+        fn test_wildcard_matches_any_negative_float(s in f64::MIN..0f64) {
+            let wildcard = Token::Wildcard;
+            let val = Token::Value(TypedToken::Float(s));
+            assert_that(&wildcard).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(wildcard);
+        }
+
+        #[test]
+        fn test_typedmatch_string_matches_any_string(s in "\\PC*") {
+            let tm = Token::TypedMatch(TypedToken::String(String::from("")));
+            let val = Token::Value(TypedToken::String(s));
+            assert_that(&tm).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(tm);
+        }
+
+        #[test]
+        fn test_typedmatch_int_matches_any_int(s in i64::MIN..i64::MAX) {
+            let tm = Token::TypedMatch(TypedToken::Int(0));
+            let val = Token::Value(TypedToken::Int(s));
+            assert_that(&tm).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(tm);
+        }
+
+        #[test]
+        fn test_typedmatch_float_matches_any_positive_float(s in 0f64..f64::MAX) {
+            let tm = Token::TypedMatch(TypedToken::Float(0.0));
+            let val = Token::Value(TypedToken::Float(s));
+            assert_that(&tm).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(tm);
+        }
+
+        #[test]
+        fn test_typedmatch_float_matches_any_negative_float(s in f64::MIN..0f64) {
+            let tm = Token::TypedMatch(TypedToken::Float(0.0));
+            let val = Token::Value(TypedToken::Float(s));
+            assert_that(&tm).is_equal_to(val.clone());
+            assert_that(&val).is_equal_to(tm);
+        }
+
+        #[test]
+        fn test_value_string_matches_same_string(s in "\\PC*") {
+            let val1 = Token::Value(TypedToken::String(s.clone()));
+            let val2 = Token::Value(TypedToken::String(s));
+            assert_that(&val1).is_equal_to(val2.clone());
+            assert_that(&val2).is_equal_to(val1);
+        }
+
+        #[test]
+        fn test_value_int_matches_same_int(s in i64::MIN..i64::MAX) {
+            let val1 = Token::Value(TypedToken::Int(s));
+            let val2 = Token::Value(TypedToken::Int(s));
+            assert_that(&val1).is_equal_to(val2.clone());
+            assert_that(&val2).is_equal_to(val1);
+        }
+
+        #[test]
+        fn test_value_float_matches_same_positive_float(s in 0f64..f64::MAX) {
+            let val1 = Token::Value(TypedToken::Float(s));
+            let val2 = Token::Value(TypedToken::Float(s));
+            assert_that(&val1).is_equal_to(val2.clone());
+            assert_that(&val2).is_equal_to(val1);
+        }
+
+        #[test]
+        fn test_value_float_matches_same_negative_float(s in f64::MIN..0f64) {
+            let val1 = Token::Value(TypedToken::Float(s));
+            let val2 = Token::Value(TypedToken::Float(s));
+            assert_that(&val1).is_equal_to(val2.clone());
+            assert_that(&val2).is_equal_to(val1);
+        }
+    }
+}


### PR DESCRIPTION
Initial naive implementation, not quite fully feature but enough to be worth getting off my laptop.

What is here:
- Core types
  - `Record` which contains the raw message, a uuid, and provides `Iterator` access to borrowed tokens
  - `Token` with variants for wildcard, typed wildcard and typed value which implements `PartialEq`
  - `TypedToken` with variants for `Int`, `Float` and `String` which derives `PartialEq`
  - `LogGroup` which is a `Record` to match against, a vector of uuids to matching records, and a vector of `Wildcard`s which are tuples of token positions and corresponding `Token` types.
  - `SimpleDrain` which is a vector of domain specific regular expressions, a nested HashMap indexed first by record length, then by first word with the inner value being a vector of `LogGroup`s, and an adjustable threshold ratio for scoring.
 
Record has a function for scoring against another record, and SimpleDrain has a function for processing a line which walks the parse tree, scores and compares against its threshold and adds new `LogGroup`s when appropriate.

What is missing:
- Updating matched Records with new wildcards as appropriate
- Any performance optimization
- Variable depth parse trees
- Other things I'm currently forgetting