### PR TITLE
Revamp strings to simplify public interface lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ ouroboros = "0.14.2"
 rksuid = { path = "../rksuid" }
 derive_more = "0.99.17"
 float_eq = "0.7.0"
+string-interner = "0.14.0"
+lazy_static = "1.4.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,16 +1,16 @@
-use crate::record::{Record, tokens::Token};
+use crate::record::{tokens::Token, Record};
 
 #[derive(Clone, Debug)]
-pub struct LogGroup<'a> {
-    event: Record<'a>,
-    examples: Vec<Record<'a>>,
+pub struct LogGroup {
+    event: Record,
+    examples: Vec<Record>,
     wildcards: Vec<Wildcard>,
 }
 
 type Wildcard = (usize, Token);
 
-impl<'a> LogGroup<'a> {
-    pub fn new(event: Record<'a>) -> Self {
+impl LogGroup {
+    pub fn new(event: Record) -> Self {
         Self {
             event: event,
             examples: vec![],
@@ -18,16 +18,16 @@ impl<'a> LogGroup<'a> {
         }
     }
 
-    pub fn add_example(&mut self, rec: Record<'a>) {
+    pub fn add_example(&mut self, rec: Record) {
         self.examples.push(rec);
     }
-    
-    pub fn event(&self) -> &Record<'a> {
+
+    pub fn event(&self) -> &Record {
         &self.event
     }
 }
 
-impl Iterator for LogGroup<'_> {
+impl Iterator for LogGroup {
     type Item = Wildcard;
     fn next(&mut self) -> Option<Wildcard> {
         None

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -33,43 +33,41 @@ impl PartialEq for Token {
                             return true;
                         }
                         false
-                    },
+                    }
                     TypedToken::Int(_) => {
                         if let TypedToken::Int(_) = other_val {
                             return true;
                         }
                         false
-                    },
+                    }
                     TypedToken::Float(_) => {
                         if let TypedToken::Float(_) = other_val {
                             return true;
                         }
                         true
-                    },
+                    }
                 },
             },
             Token::Value(val) => match other {
                 Token::Wildcard => true,
-                Token::TypedMatch(tm) => {
-                    match val {
-                        TypedToken::String(_) => {
-                            if let TypedToken::String(_) = tm {
-                                return true;
-                            }
-                            false 
-                        },
-                        TypedToken::Int(_) => {
-                            if let TypedToken::Int(_) = tm {
-                                return true;
-                            }
-                            false
-                        },
-                        TypedToken::Float(_) => {
-                            if let TypedToken::Float(_) = tm {
-                                return true
-                            }
-                            false
-                        },
+                Token::TypedMatch(tm) => match val {
+                    TypedToken::String(_) => {
+                        if let TypedToken::String(_) = tm {
+                            return true;
+                        }
+                        false
+                    }
+                    TypedToken::Int(_) => {
+                        if let TypedToken::Int(_) = tm {
+                            return true;
+                        }
+                        false
+                    }
+                    TypedToken::Float(_) => {
+                        if let TypedToken::Float(_) = tm {
+                            return true;
+                        }
+                        false
                     }
                 },
                 Token::Value(other_val) => match val {
@@ -102,8 +100,8 @@ impl Eq for Token {}
 #[cfg(test)]
 mod should {
     use crate::record::tokens::{Token, TypedToken};
-    use spectral::prelude::*;
     use proptest::prelude::*;
+    use spectral::prelude::*;
 
     #[test]
     fn test_wildcard_lhs() {


### PR DESCRIPTION
Previous interface was unusable due to lifetimes, this PR bites the bullet and takes owned strings and interns them. Lots of room yet to improve the use so allocations are probably a disaster right now but within records there should be a fair amount of re-use from the lazy_static string interner.