### PR TITLE
Add tracing, rework locks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,9 @@ derive_more = "0.99.17"
 float_eq = "0.7.0"
 string-interner = "0.14.0"
 lazy_static = "1.4.0"
+tracing = "0.1.32"
 
 [dev-dependencies]
 proptest = "1.0.0"
+tracing-test = "0.2.1"
+

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,16 +1,20 @@
+use tracing::info;
+
 use crate::record::{tokens::Token, Record};
 
 #[derive(Clone, Debug)]
 pub struct LogGroup {
     event: Record,
     examples: Vec<Record>,
-    wildcards: Vec<Wildcard>,
+    pub wildcards: Vec<Wildcard>,
 }
 
+/// A wildcard is a token position and token type
 type Wildcard = (usize, Token);
 
 impl LogGroup {
     pub fn new(event: Record) -> Self {
+        info!("new record");
         Self {
             event: event,
             examples: vec![],
@@ -19,17 +23,11 @@ impl LogGroup {
     }
 
     pub fn add_example(&mut self, rec: Record) {
+        info!(?rec, "add example");
         self.examples.push(rec);
     }
 
     pub fn event(&self) -> &Record {
         &self.event
-    }
-}
-
-impl Iterator for LogGroup {
-    type Item = Wildcard;
-    fn next(&mut self) -> Option<Wildcard> {
-        None
     }
 }


### PR DESCRIPTION
Switching from a static mutex to rwlock, despite current access patterns exclusively using write locks it no longer deadlocks at least.

Also added tracing info throughout to make debugging usage of the crate easier.