### PR TITLE
impl Display for several types

### DIFF
--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,4 +1,5 @@
-use tracing::info;
+use std::fmt;
+use tracing::instrument;
 
 use crate::record::{tokens::Token, Record};
 
@@ -13,8 +14,8 @@ pub struct LogGroup {
 type Wildcard = (usize, Token);
 
 impl LogGroup {
+    #[instrument]
     pub fn new(event: Record) -> Self {
-        info!("new record");
         Self {
             event: event,
             examples: vec![],
@@ -22,12 +23,26 @@ impl LogGroup {
         }
     }
 
+    #[instrument]
     pub fn add_example(&mut self, rec: Record) {
-        info!(?rec, "add example");
         self.examples.push(rec);
     }
 
+    #[instrument]
     pub fn event(&self) -> &Record {
         &self.event
+    }
+}
+
+impl fmt::Display for LogGroup {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "LogGroup {:?}\nEvent: {}\n{} examples and {} wildcards\n",
+            self.event.uid,
+            self.event.to_string(),
+            self.examples.len(),
+            self.wildcards.len()
+        )
     }
 }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -203,7 +203,7 @@ mod should {
 
     #[traced_test]
     #[test]
-    fn test_into_iter() {
+    fn test_consuming_iter() {
         let input = "Message send failed to remote host: foo.bar.com".to_string();
         let rec = Record::new(input.clone());
         let tokens = rec.into_iter().collect::<Vec<String>>();
@@ -212,5 +212,14 @@ mod should {
             .map(|s| s.to_owned())
             .collect::<Vec<String>>();
         assert_that(&tokens.iter()).contains_all_of(&words.iter());
+    }
+
+    #[traced_test]
+    #[test]
+    fn test_non_consuming_iter() {
+        let input = "Message send failed to remote host: foo.bar.com".to_string();
+        let rec = Record::new(input.clone());
+        let tokens = (&rec).into_iter().collect::<Vec<_>>();
+        assert_that(&tokens).has_length(7);
     }
 }


### PR DESCRIPTION
Make outputting summaries of the types easier with fmt::Display implementations. Also added a test for the by reference iterator for `Record`