### PR TITLE
Switch to string concatenation for fmt::Display

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ float_eq = "0.7.0"
 string-interner = "0.14.0"
 lazy_static = "1.4.0"
 tracing = "0.1.32"
+joinery = "2.1.0"
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -72,7 +72,7 @@ impl Record {
     pub fn first(&self) -> Option<DefaultSymbol> {
         match self.tokens.len() {
             0 => None,
-            _ => Some(self.tokens[0].clone())
+            _ => Some(self.tokens[0].clone()),
         }
     }
 


### PR DESCRIPTION
The previous method using multiple calls to write! wasn't working correctly, fix using string joining.