### PR TITLE
Variable detection in LogGroups plus Tokens and interned strings everywhere!

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,22 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.56"
+custom_derive = "0.1.7"
+derive_more = "0.99.17"
+enum_derive = "0.1.7"
+float_eq = "0.7.0"
 fraction = "0.10.0"
 itertools = "0.10.3"
-regex = "1.5"
-spectral = "0.6.0"
-ouroboros = "0.15.0"
-rksuid = { git = "https://github.com/nharring-adjacent/rksuid" }
-derive_more = "0.99.17"
-float_eq = "0.7.0"
-string-interner = "0.14.0"
 lazy_static = "1.4.0"
-tracing = "0.1.32"
 joinery = "2.1.0"
+ouroboros = "0.15.0"
+parking_lot = "0.12.0"
+regex = "1.5"
+rksuid = { git = "https://github.com/nharring-adjacent/rksuid" }
+spectral = "0.6.0"
+string-interner = "0.14.0"
+tracing = "0.1.32"
+
 
 [dev-dependencies]
 proptest = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 joinery = "2.1.0"
 ouroboros = "0.15.0"
-parking_lot = "0.12.0"
+parking_lot = { version = "0.12.0", features = ["hardware-lock-elision", "send_guard"]}
 regex = "1.5"
 rksuid = { git = "https://github.com/nharring-adjacent/rksuid" }
 spectral = "0.6.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ impl<'a> SimpleDrain {
     pub fn new(domain: Vec<String>) -> Result<Self, Error> {
         let patterns = domain
             .iter()
-            .map(|s| Regex::new(&s))
+            .map(|s| Regex::new(s))
             .collect::<Result<Vec<Regex>, regex::Error>>()?;
         Ok(Self {
             domain: patterns,
@@ -67,7 +67,7 @@ impl<'a> SimpleDrain {
     /// Err(e) for errors during processing
     #[instrument]
     pub fn process_line(&mut self, line: String) -> Result<bool, Error> {
-        if line.len() == 0 {
+        if line.is_empty() {
             return Ok(false);
         }
         let new_record = Record::new(line);
@@ -77,7 +77,7 @@ impl<'a> SimpleDrain {
             Some(second_layer) => {
                 match second_layer.get_mut(&first) {
                     Some(log_groups) => {
-                        let (score, offset) = log_groups.into_iter().enumerate().fold(
+                        let (score, offset) = log_groups.iter_mut().enumerate().fold(
                             (
                                 0, // best score
                                 0, // index of best score LogGroup
@@ -96,17 +96,17 @@ impl<'a> SimpleDrain {
                             true => {
                                 // add this record's uid to the list of examples for the log group
                                 log_groups[offset].add_example(new_record);
-                                return Ok(false);
+                                Ok(false)
                             }
                             false => {
                                 log_groups.push(LogGroup::new(new_record));
-                                return Ok(true);
+                                Ok(true)
                             }
                         }
                     }
                     None => {
                         second_layer.insert(first, vec![LogGroup::new(new_record)]);
-                        return Ok(true);
+                        Ok(true)
                     }
                 }
             }
@@ -117,7 +117,7 @@ impl<'a> SimpleDrain {
                     .get_mut(&length)
                     .expect("We just inserted this map");
                 second_layer.insert(first, vec![LogGroup::new(new_record)]);
-                return Ok(true);
+                Ok(true)
             }
         }
     }

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -19,7 +19,7 @@ impl LogGroup {
     #[instrument]
     pub fn new(event: Record) -> Self {
         Self {
-            event: event,
+            event,
             examples: vec![],
             variables: HashMap::new(),
         }
@@ -46,16 +46,14 @@ impl LogGroup {
                 if let Some(_) = self.variables.get(idx) {
                     // This token has already been identified as a variable
                     false
+                } else if event != candidate {
+                    info!(%idx, ?event, ?candidate, "found candidate");
+                    true
                 } else {
-                    if event != candidate {
-                        info!(%idx, ?event, ?candidate, "found candidate");
-                        true
-                    } else {
-                        false
-                    }
+                    false
                 }
             })
-            .filter_map(|((idx, event), candidate)| Some((idx, Token::Wildcard)))
+            .filter_map(|((idx, _event), _candidate)| Some((idx, Token::Wildcard)))
             .collect::<Vec<_>>();
         Ok(f)
     }
@@ -75,7 +73,7 @@ impl fmt::Display for LogGroup {
             "LogGroup ID: {}\nFirst Seen: {}\nEvent: {}\n{} examples and {} wildcards\n",
             self.event.uid.serialize(),
             self.event.uid.get_time(),
-            self.event.to_string(),
+            self.event,
             self.examples.len(),
             self.variables.len()
         )
@@ -88,7 +86,7 @@ mod should {
         log_group::LogGroup,
         record::{tokens::Token, Record},
     };
-    use proptest::prelude::*;
+    
     use spectral::prelude::*;
     use std::collections::HashMap;
 

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -1,5 +1,7 @@
-use std::fmt;
-use tracing::instrument;
+use std::{borrow::Borrow, collections::HashMap, fmt};
+
+use anyhow::Error;
+use tracing::{info, instrument};
 
 use crate::record::{tokens::Token, Record};
 
@@ -7,11 +9,11 @@ use crate::record::{tokens::Token, Record};
 pub struct LogGroup {
     event: Record,
     examples: Vec<Record>,
-    pub wildcards: Vec<Wildcard>,
+    pub variables: HashMap<usize, Token>,
 }
 
-/// A wildcard is a token position and token type
-type Wildcard = (usize, Token);
+/// A wildcard is an offset and a token
+pub type Wildcard = (usize, Token);
 
 impl LogGroup {
     #[instrument]
@@ -19,7 +21,7 @@ impl LogGroup {
         Self {
             event: event,
             examples: vec![],
-            wildcards: vec![],
+            variables: HashMap::new(),
         }
     }
 
@@ -32,6 +34,38 @@ impl LogGroup {
     pub fn event(&self) -> &Record {
         &self.event
     }
+
+    fn discover_variables(&self, rec: &Record) -> Result<Vec<Wildcard>, Error> {
+        let f = self
+            .event
+            .borrow()
+            .into_iter()
+            .enumerate()
+            .zip(rec.into_iter())
+            .filter(|((idx, event), candidate)| {
+                if let Some(_) = self.variables.get(idx) {
+                    // This token has already been identified as a variable
+                    false
+                } else {
+                    if event != candidate {
+                        info!(%idx, ?event, ?candidate, "found candidate");
+                        true
+                    } else {
+                        false
+                    }
+                }
+            })
+            .filter_map(|((idx, event), candidate)| Some((idx, Token::Wildcard)))
+            .collect::<Vec<_>>();
+        Ok(f)
+    }
+
+    fn updaate_variables(&mut self, vars: Vec<(usize, Token)>) {
+        for var in vars {
+            // Assume we got vars from discover_variab les so it has already checked against this map
+            self.variables.insert(var.0, var.1);
+        }
+    }
 }
 
 impl fmt::Display for LogGroup {
@@ -43,7 +77,51 @@ impl fmt::Display for LogGroup {
             self.event.uid.get_time(),
             self.event.to_string(),
             self.examples.len(),
-            self.wildcards.len()
+            self.variables.len()
         )
     }
+}
+
+#[cfg(test)]
+mod should {
+    use crate::{
+        log_group::LogGroup,
+        record::{tokens::Token, Record},
+    };
+    use proptest::prelude::*;
+    use spectral::prelude::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_discover_variables() {
+        let rec1 = Record::new("Common prefix Common prefix Common prefix 1234".to_string());
+        let lg = LogGroup {
+            event: rec1.clone(),
+            examples: vec![rec1],
+            variables: HashMap::new(),
+        };
+        let rec2 = Record::new("Common prefix Common prefix Common prefix 3456".to_string());
+        let vars = lg.discover_variables(&rec2);
+        assert_that(&vars).is_ok_containing(vec![(6, Token::Wildcard)]);
+    }
+
+    #[test]
+    fn test_update_variables() {
+        let rec1 = Record::new("Common prefix Common prefix Common prefix 1234".to_string());
+        let mut lg = LogGroup {
+            event: rec1.clone(),
+            examples: vec![rec1],
+            variables: HashMap::new(),
+        };
+        let rec2 = Record::new("Common prefix Common prefix Common prefix 3456".to_string());
+        let vars = lg.discover_variables(&rec2).unwrap();
+        lg.updaate_variables(vars);
+        assert_that(&lg.variables).contains_key(6);
+    }
+
+    // prop_compose! {
+    //     fn generate_line_pair(words: usize, variables: usize) -> (String, String) {
+
+    //     }
+    // }
 }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,17 +1,17 @@
 pub mod tokens;
 extern crate derive_more;
 
-use std::{collections::HashMap, fmt, sync::Arc};
+use std::{fmt};
 
 use crate::INTERNER;
-use itertools::Itertools;
-use lazy_static::lazy_static;
-use parking_lot::RwLock;
-use rksuid::rksuid;
-use string_interner::{DefaultSymbol, StringInterner};
-use tracing::{info, instrument};
 
-use self::tokens::{Grokker, Token, TokenStream, TypedToken};
+use lazy_static::lazy_static;
+
+use rksuid::rksuid;
+use string_interner::{DefaultSymbol};
+use tracing::{instrument};
+
+use self::tokens::{Token, TokenStream, TypedToken};
 
 lazy_static! {
     static ref ASTERISK: DefaultSymbol = INTERNER.write().get_or_intern_static("*");
@@ -47,10 +47,7 @@ impl Record {
 
     #[instrument]
     pub fn first(&self) -> Option<DefaultSymbol> {
-        match self.inner.first() {
-            Some(f) => Some(f.into()),
-            None => None,
-        }
+        self.inner.first().map(|f| f.into())
     }
 
     #[instrument]
@@ -60,10 +57,7 @@ impl Record {
 
     #[instrument]
     pub fn resolve(sym: DefaultSymbol) -> Option<String> {
-        match INTERNER.read().resolve(sym) {
-            Some(s) => Some(s.to_owned()),
-            None => None,
-        }
+        INTERNER.read().resolve(sym).map(|s| s.to_owned())
     }
 }
 
@@ -202,7 +196,7 @@ mod should {
     #[test]
     fn test_non_consuming_iter() {
         let input = "Message send failed to remote host: foo.bar.com".to_string();
-        let rec = Record::new(input.clone());
+        let rec = Record::new(input);
         let tokens = (&rec).into_iter().collect::<Vec<_>>();
         assert_that(&tokens).has_length(7);
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,89 +1,66 @@
 pub mod tokens;
 extern crate derive_more;
 
-use std::fmt;
-use std::sync::RwLock;
+use std::{collections::HashMap, fmt, sync::Arc};
 
+use crate::INTERNER;
 use itertools::Itertools;
 use lazy_static::lazy_static;
+use parking_lot::RwLock;
 use rksuid::rksuid;
 use string_interner::{DefaultSymbol, StringInterner};
 use tracing::{info, instrument};
 
+use self::tokens::{Grokker, Token, TokenStream, TypedToken};
+
 lazy_static! {
-    static ref INTERNER: RwLock<StringInterner> = RwLock::new(StringInterner::default());
+    static ref ASTERISK: DefaultSymbol = INTERNER.write().get_or_intern_static("*");
+    
 }
 #[derive(Clone, Debug)]
 pub struct Record {
-    interner: &'static RwLock<StringInterner>,
-    pub raw_message: DefaultSymbol,
-    tokens: Vec<DefaultSymbol>,
-    // pos: usize,
+    inner: TokenStream,
     pub uid: rksuid::Ksuid,
 }
 impl Record {
+    #[instrument]
     pub fn new(line: String) -> Self {
-        info!(%line, "new record from");
-        let mut interner = INTERNER.write().expect("lock is valid");
         Self {
-            interner: &INTERNER,
-            raw_message: interner.get_or_intern(line.clone()),
-            tokens: line
-                .as_str()
-                .char_indices()
-                .filter(|t| {
-                    (t.0 == 0 && !t.1.is_whitespace()) // The very first char needs special handling
-                        || (t.1.is_whitespace()
-                            && line
-                                .chars()
-                                .clone()
-                                .nth(t.0 - 1)
-                                .and_then(|c| Some(!c.is_whitespace()))
-                                .unwrap())
-                })
-                .map(|t| t.0)
-                .chain(vec![line.len()].into_iter())
-                .tuple_windows::<(_, _)>()
-                .map(|t| (if t.0 == 0 { t.0 } else { t.0 + 1 }, t.1))
-                .map(|t| interner.get_or_intern(line.as_str().get(t.0..t.1).unwrap().to_owned()))
-                .collect::<Vec<DefaultSymbol>>(),
-            // pos: 0,
+            inner: TokenStream::from_line(&line),
             uid: rksuid::new(None, None),
         }
     }
 
+    #[instrument]
     pub fn calc_sim_score(&self, candidate: &Record) -> u64 {
-        info!("calculating similarity score");
         let pairs = self
             .into_iter()
             .zip(candidate.into_iter())
             .collect::<Vec<(_, _)>>();
-        info!(length = %pairs.len(), " pairs being used");
-        let mut interner = INTERNER.write().expect("RwLock is live");
+        // let mut interner = INTERNER.write();
         let score = pairs
             .iter()
-            .filter(|pair| pair.0 == pair.1 || pair.1 == interner.get_or_intern_static("*"))
+            .filter(|(this, other)| this == other)
             .fold(0_u64, |acc, _pair| acc + 1);
-        info!(%score, "score calculated");
         score
     }
 
     #[instrument]
     pub fn first(&self) -> Option<DefaultSymbol> {
-        match self.tokens.len() {
-            0 => None,
-            _ => Some(self.tokens[0].clone()),
+        match self.inner.first() {
+            Some(f) => Some(f.into()),
+            None => None,
         }
     }
 
     #[instrument]
     pub fn len(&self) -> usize {
-        self.tokens.len()
+        self.inner.len()
     }
 
     #[instrument]
-    pub fn resolve(&self, sym: DefaultSymbol) -> Option<String> {
-        match self.interner.read().unwrap().resolve(sym) {
+    pub fn resolve(sym: DefaultSymbol) -> Option<String> {
+        match INTERNER.read().resolve(sym) {
             Some(s) => Some(s.to_owned()),
             None => None,
         }
@@ -103,16 +80,28 @@ pub struct RecordRefIterator<'a> {
 impl Iterator for RecordIntoIter {
     type Item = String;
     fn next(&mut self) -> Option<String> {
-        if self.index >= self.record.tokens.len() {
+        if self.index >= self.record.len() {
             return None;
         }
-        let val = self.record.tokens[self.index];
+        let sym = match self.record.inner.get_token_at_index(self.index) {
+            Some(t) => match t {
+                tokens::Token::Wildcard => "*".to_string(),
+                tokens::Token::TypedMatch(t) => format!("{}", t),
+                tokens::Token::Value(v) => match v {
+                    TypedToken::String(sym) => INTERNER
+                        .read()
+                        .resolve(sym)
+                        .expect("symbol failed to resolve")
+                        .to_owned(),
+                    TypedToken::Int(i) => i.to_string(),
+                    TypedToken::Float(f) => f.to_string(),
+                },
+            },
+            None => todo!(),
+        };
+
         self.index += 1;
-        Some(
-            self.record
-                .resolve(val)
-                .expect("records can resolve their own tokens"),
-        )
+        Some(sym)
     }
 }
 
@@ -127,18 +116,17 @@ impl IntoIterator for Record {
     }
 }
 impl<'a> Iterator for RecordRefIterator<'a> {
-    type Item = DefaultSymbol;
-    fn next(&mut self) -> Option<DefaultSymbol> {
-        if self.index >= self.record.tokens.len() {
-            return None;
+    type Item = Token;
+    fn next(&mut self) -> Option<Token> {
+        if let Some(val) = self.record.inner.get_token_at_index(self.index) {
+            self.index += 1;
+            return Some(val);
         }
-        let val = self.record.tokens[self.index];
-        self.index += 1;
-        Some(val)
+        None
     }
 }
 impl<'a> IntoIterator for &'a Record {
-    type Item = DefaultSymbol;
+    type Item = Token;
     type IntoIter = RecordRefIterator<'a>;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -151,20 +139,13 @@ impl<'a> IntoIterator for &'a Record {
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "{}",
-            INTERNER
-                .read()
-                .unwrap()
-                .resolve(self.raw_message)
-                .expect("interned strings must stay resolvable")
-        )
+        write!(f, "{}", self.inner)
     }
 }
 #[cfg(test)]
 mod should {
     use crate::Record;
+    use crate::INTERNER;
     use spectral::prelude::*;
     use tracing_test::traced_test;
 
@@ -192,8 +173,8 @@ mod should {
     fn test_record_first() {
         let input = "Message send failed to remote host: foo.bar.com".to_string();
         let rec = Record::new(input);
-        let val = rec.first();
-        assert_eq!(rec.resolve(val.unwrap()).unwrap(), "Message");
+        let val = rec.first().unwrap();
+        assert_eq!(INTERNER.read().resolve(val).unwrap(), "Message");
     }
 
     #[traced_test]

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -1,23 +1,232 @@
+use std::{fmt, collections::HashMap};
+
+use crate::INTERNER;
+use anyhow::Error;
 use float_eq::float_eq;
+use itertools::Itertools;
+use joinery::JoinableIterator;
+use lazy_static::lazy_static;
+use regex::RegexSet;
+use string_interner::DefaultSymbol;
+
+use super::ASTERISK;
+
+lazy_static! {
+    static ref MATCHERS: RegexSet = Grokker::build_pattern_set();
+    static ref GROKKER_COUNT: usize = Grokker::iter_variants().count() - 1;
+    static ref GROKKER_SYMS: HashMap<Grokker, DefaultSymbol> = symbolize_grokker();
+    
+}
+
+fn symbolize_grokker() -> HashMap<Grokker, DefaultSymbol> {
+    Grokker::iter_variants()
+        .map(|v| (v, INTERNER.write().get_or_intern(&v.to_string())))
+        .collect::<HashMap<Grokker, DefaultSymbol>>()
+}
+
+custom_derive! {
+    #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, IterVariants(GrokkerVariants), EnumDisplay)]
+    pub enum Grokker {
+        Base10Integer,
+        Base10Float,
+        Base16Integer,
+        Base16Float,
+        QuotedString,
+        Word,
+        UUID,
+        MAC,
+        IPv6,
+        IPv4,
+        Hostname,
+        Month,
+        Day,
+    }
+}
+
+impl Grokker {
+    fn to_pattern(&self) -> String {
+        match self {
+            Grokker::Base10Integer => r"(?:[+-]?(?:[0-9]+))".to_string(),
+            Grokker::Base10Float => {
+                r"(?<![0-9.+-])(?>[+-]?(?:(?:[0-9]+(?:\.[0-9]+)?)|(?:\.[0-9]+)))".to_string()
+            }
+            Grokker::Base16Integer => r"(?<![0-9A-Fa-f])(?:[+-]?(?:0x)?(?:[0-9A-Fa-f]+))".to_string(),
+            Grokker::Base16Float => {
+                r"\b(?<![0-9A-Fa-f.])(?:[+-]?(?:0x)?(?:(?:[0-9A-Fa-f]+(?:\.[0-9A-Fa-f]*)?)|(?:\.[0-9A-Fa-f]+)))\b".to_string()
+            }
+            Grokker::QuotedString => {
+                r#"(?>(?<!\\)(?>"(?>\\.|[^\\"]+)+"|""|(?>'(?>\\.|[^\\']+)+')|''|(?>`(?>\\.|[^\\`]+)+`)|``))"#.to_string()
+            }
+            Grokker::Word => r"\b\w+\b".to_string(),
+            Grokker::UUID => r"[A-Fa-f0-9]{8}-(?:[A-Fa-f0-9]{4}-){3}[A-Fa-f0-9]{12}".to_string(),
+            Grokker::MAC => r"(?:(?:[A-Fa-f0-9]{2}:){5}[A-Fa-f0-9]{2})".to_string(),
+            Grokker::IPv6 => {
+                r"((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))(%.+)?".to_string()
+            }
+            Grokker::IPv4 => {
+                r"(?<![0-9])(?:(?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])[.](?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])[.](?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5])[.](?:[0-1]?[0-9]{1,2}|2[0-4][0-9]|25[0-5]))(?![0-9])".to_string()
+            }
+            Grokker::Hostname => {
+                r"\b(?:[0-9A-Za-z][0-9A-Za-z-]{0,62})(?:\.(?:[0-9A-Za-z][0-9A-Za-z-]{0,62}))*(\.?|\b)".to_string()
+            }
+            Grokker::Month => {
+                r"\b(?:[Jj]an(?:uary|uar)?|[Ff]eb(?:ruary|ruar)?|[Mm](?:a|ä)?r(?:ch|z)?|[Aa]pr(?:il)?|[Mm]a(?:y|i)?|[Jj]un(?:e|i)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo](?:c|k)?t(?:ober)?|[Nn]ov(?:ember)?|[Dd]e(?:c|z)(?:ember)?)\b".to_string()
+            }
+            Grokker::Day => {
+                r"(?:Mon(?:day)?|Tue(?:sday)?|Wed(?:nesday)?|Thu(?:rsday)?|Fri(?:day)?|Sat(?:urday)?|Sun(?:day)?)".to_string()
+            }
+        }
+    }
+
+    fn build_pattern_set() -> RegexSet {
+        let variants = Grokker::iter_variants()
+            .map(|v| v.to_pattern())
+            .collect::<Vec<String>>();
+        RegexSet::new(variants).expect("valid regular expressions compile")
+    }
+
+    pub fn from_match_index(idx: usize) -> Option<Grokker> {
+        if idx > *GROKKER_COUNT {
+            return None;
+        }
+        Some(Grokker::iter_variants().collect::<Vec<Grokker>>()[idx])
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum Token {
     /// Token that matches any other token
     Wildcard,
     /// Token that matches any value of the inner type
-    TypedMatch(TypedToken),
+    TypedMatch(Grokker),
     /// Token containing a typed, non-wildcard value
     Value(TypedToken),
+}
+
+impl fmt::Display for Token {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let out: String = match self {
+            Token::Wildcard => "*".to_string(),
+            Token::TypedMatch(t) => t.to_string(),
+            Token::Value(v) => match v {
+                TypedToken::String(sym) => INTERNER
+                    .read()
+                    .resolve(*sym)
+                    .expect("symbols must resolve")
+                    .to_string(),
+                TypedToken::Int(i) => format!("{}", i),
+                TypedToken::Float(f) => f.to_string(),
+            },
+        };
+        write!(f, "{}", out)
+    }
+}
+
+impl From<Token> for DefaultSymbol {
+    fn from(tok: Token) -> DefaultSymbol {
+        match tok {
+            Token::Wildcard => *ASTERISK,
+            Token::TypedMatch(t) => *GROKKER_SYMS.get(&t).expect("every grokker must have a symbol"),
+            Token::Value(v) => match v {
+                TypedToken::String(s) => s,
+                TypedToken::Int(i) => INTERNER.write().get_or_intern(i.to_string()),
+                TypedToken::Float(f) => INTERNER.write().get_or_intern(f.to_string()),
+            },
+        }
+    }
 }
 
 #[derive(PartialEq, Debug, Clone)]
 pub enum TypedToken {
     /// Token containing a string with at least 1 non-digit
-    String(String),
+    String(DefaultSymbol),
     /// Token containing a whole number only
     Int(i64),
     /// Token containing a float
     Float(f64),
+}
+
+impl TypedToken {
+    pub fn from_parse(input: &str) -> Result<TypedToken, Error> {
+        let tok = INTERNER.write().get_or_intern(input);
+        Ok(TypedToken::String(tok))
+    }
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub struct Offset {
+    start: usize,
+    end: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TokenStream {
+    inner: Vec<(Offset, Token)>,
+}
+
+impl TokenStream {
+    pub fn from_line(line: &str) -> Self {
+        let mut interner = INTERNER.write();
+        let tokens = line
+            .char_indices()
+            .filter(|t| {
+                (t.0 == 0 && !t.1.is_whitespace()) // The very first char needs special handling
+                || (t.1.is_whitespace()
+                    && line
+                        .chars()
+                        .clone()
+                        .nth(t.0 - 1)
+                        .and_then(|c| Some(!c.is_whitespace()))
+                        .unwrap())
+            })
+            .map(|t| t.0)
+            .chain(vec![line.len()].into_iter())
+            .tuple_windows::<(_, _)>()
+            .map(|t| (if t.0 == 0 { t.0 } else { t.0 + 1 }, t.1))
+            .map(|t| {
+                (
+                    Offset {
+                        start: t.0,
+                        end: t.1,
+                    },
+                    Token::Value(TypedToken::String(
+                        interner.get_or_intern(line.get(t.0..t.1).unwrap().to_owned()),
+                    )),
+                )
+            })
+            .collect::<Vec<(Offset, Token)>>();
+        Self { inner: tokens }
+    }
+
+    pub fn first(&self) -> Option<Token> {
+        match self.inner.len() {
+            0 => None,
+            _ => Some(self.inner[0].1.clone()),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn get_token_at_index(&self, idx: usize) -> Option<Token> {
+        match idx < self.inner.len() {
+            true => Some(self.inner[idx].1.clone()),
+            false => None,
+        }
+    }
+}
+
+impl fmt::Display for TokenStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        //TODO: make use of offset to correctly restore whitespace
+        let disp = self
+            .inner
+            .iter()
+            .map(|(_offset, token)| token)
+            .join_with(" ");
+        write!(f, "{}", disp.to_string())
+    }
 }
 
 impl PartialEq for Token {
@@ -27,48 +236,14 @@ impl PartialEq for Token {
             Token::TypedMatch(tm) => match other {
                 Token::Wildcard => true,
                 Token::TypedMatch(otm) => tm == otm,
-                Token::Value(other_val) => match tm {
-                    TypedToken::String(_) => {
-                        if let TypedToken::String(_) = other_val {
-                            return true;
-                        }
-                        false
-                    }
-                    TypedToken::Int(_) => {
-                        if let TypedToken::Int(_) = other_val {
-                            return true;
-                        }
-                        false
-                    }
-                    TypedToken::Float(_) => {
-                        if let TypedToken::Float(_) = other_val {
-                            return true;
-                        }
-                        true
-                    }
-                },
+                Token::Value(_) => false,
             },
             Token::Value(val) => match other {
                 Token::Wildcard => true,
-                Token::TypedMatch(tm) => match val {
-                    TypedToken::String(_) => {
-                        if let TypedToken::String(_) = tm {
-                            return true;
-                        }
-                        false
-                    }
-                    TypedToken::Int(_) => {
-                        if let TypedToken::Int(_) = tm {
-                            return true;
-                        }
-                        false
-                    }
-                    TypedToken::Float(_) => {
-                        if let TypedToken::Float(_) = tm {
-                            return true;
-                        }
-                        false
-                    }
+                Token::TypedMatch(_) => match val {
+                    TypedToken::String(_) => false,
+                    TypedToken::Int(_) => false,
+                    TypedToken::Float(_) => false,
                 },
                 Token::Value(other_val) => match val {
                     TypedToken::String(string_val) => {
@@ -100,13 +275,16 @@ impl Eq for Token {}
 #[cfg(test)]
 mod should {
     use crate::record::tokens::{Token, TypedToken};
+    use crate::INTERNER;
     use proptest::prelude::*;
     use spectral::prelude::*;
 
     #[test]
     fn test_wildcard_lhs() {
         let lhs = Token::Wildcard;
-        let rhs = Token::Value(TypedToken::String("foo".to_string()));
+        let rhs = Token::Value(TypedToken::String(
+            INTERNER.write().get_or_intern("foo".to_string()),
+        ));
         assert_that(&lhs).is_equal_to(rhs.clone());
         assert_that(&rhs).is_equal_to(lhs);
     }
@@ -115,7 +293,7 @@ mod should {
         #[test]
         fn test_wildcard_matches_any_string(s in "\\PC*") {
             let wildcard = Token::Wildcard;
-            let val = Token::Value(TypedToken::String(s));
+            let val = Token::Value(TypedToken::String(INTERNER.write().get_or_intern(s)));
             assert_that(&wildcard).is_equal_to(val.clone());
             assert_that(&val).is_equal_to(wildcard);
         }
@@ -145,41 +323,9 @@ mod should {
         }
 
         #[test]
-        fn test_typedmatch_string_matches_any_string(s in "\\PC*") {
-            let tm = Token::TypedMatch(TypedToken::String(String::from("")));
-            let val = Token::Value(TypedToken::String(s));
-            assert_that(&tm).is_equal_to(val.clone());
-            assert_that(&val).is_equal_to(tm);
-        }
-
-        #[test]
-        fn test_typedmatch_int_matches_any_int(s in i64::MIN..i64::MAX) {
-            let tm = Token::TypedMatch(TypedToken::Int(0));
-            let val = Token::Value(TypedToken::Int(s));
-            assert_that(&tm).is_equal_to(val.clone());
-            assert_that(&val).is_equal_to(tm);
-        }
-
-        #[test]
-        fn test_typedmatch_float_matches_any_positive_float(s in 0f64..f64::MAX) {
-            let tm = Token::TypedMatch(TypedToken::Float(0.0));
-            let val = Token::Value(TypedToken::Float(s));
-            assert_that(&tm).is_equal_to(val.clone());
-            assert_that(&val).is_equal_to(tm);
-        }
-
-        #[test]
-        fn test_typedmatch_float_matches_any_negative_float(s in f64::MIN..0f64) {
-            let tm = Token::TypedMatch(TypedToken::Float(0.0));
-            let val = Token::Value(TypedToken::Float(s));
-            assert_that(&tm).is_equal_to(val.clone());
-            assert_that(&val).is_equal_to(tm);
-        }
-
-        #[test]
         fn test_value_string_matches_same_string(s in "\\PC*") {
-            let val1 = Token::Value(TypedToken::String(s.clone()));
-            let val2 = Token::Value(TypedToken::String(s));
+            let val1 = Token::Value(TypedToken::String(INTERNER.write().get_or_intern(s.clone())));
+            let val2 = Token::Value(TypedToken::String(INTERNER.write().get_or_intern(s)));
             assert_that(&val1).is_equal_to(val2.clone());
             assert_that(&val2).is_equal_to(val1);
         }

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -175,8 +175,7 @@ impl TokenStream {
                     && line
                         .chars()
                         .clone()
-                        .nth(t.0 - 1)
-                        .and_then(|c| Some(!c.is_whitespace()))
+                        .nth(t.0 - 1).map(|c| !c.is_whitespace())
                         .unwrap())
             })
             .map(|t| t.0)
@@ -190,7 +189,7 @@ impl TokenStream {
                         end: t.1,
                     },
                     Token::Value(TypedToken::String(
-                        interner.get_or_intern(line.get(t.0..t.1).unwrap().to_owned()),
+                        interner.get_or_intern(line.get(t.0..t.1).unwrap()),
                     )),
                 )
             })
@@ -225,13 +224,13 @@ impl fmt::Display for TokenStream {
             .iter()
             .map(|(_offset, token)| token)
             .join_with(" ");
-        write!(f, "{}", disp.to_string())
+        write!(f, "{}", disp)
     }
 }
 
 impl PartialEq for Token {
     fn eq(&self, other: &Self) -> bool {
-        return match self {
+        match self {
             Token::Wildcard => true,
             Token::TypedMatch(tm) => match other {
                 Token::Wildcard => true,
@@ -266,7 +265,7 @@ impl PartialEq for Token {
                     }
                 },
             },
-        };
+        }
     }
 }
 
@@ -283,7 +282,7 @@ mod should {
     fn test_wildcard_lhs() {
         let lhs = Token::Wildcard;
         let rhs = Token::Value(TypedToken::String(
-            INTERNER.write().get_or_intern("foo".to_string()),
+            INTERNER.write().get_or_intern("foo"),
         ));
         assert_that(&lhs).is_equal_to(rhs.clone());
         assert_that(&rhs).is_equal_to(lhs);


### PR DESCRIPTION
Two big changes in this pr:
1. `LogGroup::detect_variables()` and `LogGroup::update_variables()` which implement step 5 from the original paper which replaces tokens which do not match between the parse tree string and the record being compared.
2. Replace a lot of passing around of owned strings with `string_interner::DefaultSymbol` instead. This also involved adding some more robustness around `Token`s, with the new `TokenStream` as a replacement for storing a `&str` inline in the `Record` struct. There is still some inefficiency with regard to int and float values but getting closer and closer to a zero-copy internal implementation.