### PR TITLE
Add some benchmarks and configure criterion

### DIFF
--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -2,7 +2,7 @@ name: Rust Benchmark
 on:
   push:
     branches:
-      - master
+      - trunk
 
 permissions:
   contents: write

--- a/.github/workflows/rust-benchmark.yml
+++ b/.github/workflows/rust-benchmark.yml
@@ -1,0 +1,32 @@
+name: Rust Benchmark
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run Rust benchmark example
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup toolchain update nightly && rustup default nightly
+      - name: Run benchmark
+        run: cargo +nightly bench | tee output.txt
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Rust Benchmark
+          tool: 'cargo'
+          output-file-path: examples/rust/output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true
+          alert-comment-cc-users: '@nharring-adjacent'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,11 @@ tracing = "0.1.32"
 
 
 [dev-dependencies]
+criterion = "0.3"
 proptest = "1.0.0"
 tracing-test = "0.2.1"
+
+[[bench]]
+name = "core_benchmarks"
+harness = false
 

--- a/benches/core_benchmarks.rs
+++ b/benches/core_benchmarks.rs
@@ -1,0 +1,62 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+
+use drain_flow::log_group::LogGroup;
+use drain_flow::record::Record;
+use drain_flow::SimpleDrain;
+
+// Really simplistic benchmark of adding new lines using a constant line
+// this is pretty unrealistic since after the first one the string interner
+// will be doing almost no work but its a start
+pub fn benchmark_new_lines(c: &mut Criterion) {
+    let mut drain = SimpleDrain::new(vec![]).unwrap();
+    c.bench_function("new_lines", |b| {
+        b.iter(|| {
+            drain.process_line(black_box(
+                "Sample line with a few words to score".to_string(),
+            ))
+        })
+    });
+}
+
+pub fn benchmark_calculate_score(c: &mut Criterion) {
+    let rec1 = Record::new("Sample line with a few words to score".to_string());
+    let rec2 = Record::new("Different log line which will not match".to_string());
+    c.bench_function("calculate_simscore", |b| {
+        b.iter(|| {
+            rec1.calc_sim_score(black_box(&rec2));
+        });
+    });
+}
+
+pub fn benchmark_find_variables(c: &mut Criterion) {
+    let rec1 = Record::new("Sample line with a few words to score: 12345".to_string());
+    let rec2 = Record::new("Sample line with a few words to score: 65432123".to_string());
+
+    let lg = LogGroup::new(rec1);
+    c.bench_function("find_variables", |b| {
+        b.iter(|| {
+            lg.discover_variables(black_box(&rec2)).unwrap();
+        });
+    });
+}
+
+pub fn benchmark_add_example(c: &mut Criterion) {
+    let rec1 = Record::new("Sample line with a few words to score: 12345".to_string());
+    let rec2 = Record::new("Sample line with a few words to score: 65432123".to_string());
+    let mut lg = LogGroup::new(rec1);
+
+    c.bench_function("add_example", |b| {
+        b.iter(|| {
+            lg.add_example(rec2.clone());
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    benchmark_new_lines,
+    benchmark_calculate_score,
+    benchmark_find_variables,
+    benchmark_add_example
+);
+criterion_main!(benches);

--- a/criterion.toml
+++ b/criterion.toml
@@ -1,0 +1,45 @@
+# This is used to override the directory where cargo-criterion saves 
+# its data and generates reports.
+criterion_home = "./target/criterion"
+
+# This is used to configure the format of cargo-criterion's command-line output.
+# Options are:
+# criterion: Prints confidence intervals for measurement and throughput, and 
+#   indicates whether a change was detected from the previous run. The default.
+# quiet: Like criterion, but does not indicate changes. Useful for simply 
+#   presenting output numbers, eg. on a library's README.
+# verbose: Like criterion, but prints additional statistics.
+# bencher: Emulates the output format of the bencher crate and nightly-only 
+#   libtest benchmarks.
+output_format = "criterion"
+
+# This is used to configure the plotting backend used by cargo-criterion. 
+# Options are "gnuplot" and "plotters", or "auto", which will use gnuplot if it's
+# available or plotters if it isn't.
+ploting_backend = "auto"
+
+# The colors table allows users to configure the colors used by the charts 
+# cargo-criterion generates.
+[colors]
+# These are used in many charts to compare the current measurement against 
+# the previous one.
+current_sample = {r = 31, g = 120, b = 180}
+previous_sample = {r = 7, g = 26, b = 28}
+
+# These are used by the full PDF chart to highlight which samples were outliers.
+not_an_outlier = {r = 31, g = 120, b = 180}
+mild_outlier = {r = 5, g = 127, b = 0}
+severe_outlier = {r = 7, g = 26, b = 28}
+
+# These are used for the line chart to compare multiple different functions.
+comparison_colors = [
+    {r = 8, g = 34, b = 34},
+    {r = 6, g = 139, b = 87},
+    {r = 0, g = 139, b = 139},
+    {r = 5, g = 215, b = 0},
+    {r = 0, g = 0, b = 139},
+    {r = 0, g = 20, b = 60},
+    {r = 9, g = 0, b = 139},
+    {r = 0, g = 255, b = 127},
+]
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ impl<'a> SimpleDrain {
         }
     }
 
+    #[instrument]
     pub fn iter_groups(&self) -> Vec<Vec<&LogGroup>> {
         let mut results: Vec<Vec<&LogGroup>> = Vec::new();
         for length in self.base_layer.keys() {
@@ -136,6 +137,7 @@ impl<'a> SimpleDrain {
         results
     }
 
+    #[instrument]
     pub fn resolve(&self, sym: DefaultSymbol) -> String {
         self.strings
             .read()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,9 @@ impl<'a> SimpleDrain {
     #[instrument]
     pub fn set_threshold(&mut self, numerator: u64, denominator: u64) -> Result<(), Error> {
         let numer = BigInt::from_u64(numerator)
-            .ok_or(anyhow!("unable to make numerator from {}", numerator))?;
+            .ok_or_else(|| anyhow!("unable to make numerator from {}", numerator))?;
         let denom = BigInt::from_u64(denominator)
-            .ok_or(anyhow!("unable to make denominator from {}", denominator))?;
+            .ok_or_else(|| anyhow!("unable to make denominator from {}", denominator))?;
         let new_ratio = Ratio::new(numer, denom);
         self.threshold = new_ratio;
         Ok(())

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -27,7 +27,11 @@ impl LogGroup {
 
     #[instrument]
     pub fn add_example(&mut self, rec: Record) {
+        let vars = self.discover_variables(&rec).unwrap();
         self.examples.push(rec);
+        if vars.len() > 0 {
+            self.updaate_variables(vars);
+        }
     }
 
     #[instrument]
@@ -35,7 +39,7 @@ impl LogGroup {
         &self.event
     }
 
-    fn discover_variables(&self, rec: &Record) -> Result<Vec<Wildcard>, Error> {
+    pub fn discover_variables(&self, rec: &Record) -> Result<Vec<Wildcard>, Error> {
         let f = self
             .event
             .borrow()

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -47,7 +47,7 @@ impl LogGroup {
             .enumerate()
             .zip(rec.into_iter())
             .filter(|((idx, event), candidate)| {
-                if let Some(_) = self.variables.get(idx) {
+                if self.variables.get(idx).is_some() {
                     // This token has already been identified as a variable
                     false
                 } else if event != candidate {
@@ -57,7 +57,7 @@ impl LogGroup {
                     false
                 }
             })
-            .filter_map(|((idx, _event), _candidate)| Some((idx, Token::Wildcard)))
+            .map(|((idx, _event), _candidate)| (idx, Token::Wildcard))
             .collect::<Vec<_>>();
         Ok(f)
     }

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -29,7 +29,7 @@ impl LogGroup {
     pub fn add_example(&mut self, rec: Record) {
         let vars = self.discover_variables(&rec).unwrap();
         self.examples.push(rec);
-        if vars.len() > 0 {
+        if !vars.is_empty() {
             self.updaate_variables(vars);
         }
     }
@@ -90,7 +90,7 @@ mod should {
         log_group::LogGroup,
         record::{tokens::Token, Record},
     };
-    
+
     use spectral::prelude::*;
     use std::collections::HashMap;
 

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -54,6 +54,10 @@ impl Record {
         self.inner.len()
     }
 
+    pub fn is_empty(&self) -> bool {
+        self.inner.len() == 0
+    }
+
     #[instrument]
     pub fn resolve(sym: DefaultSymbol) -> Option<String> {
         INTERNER.read().resolve(sym).map(|s| s.to_owned())

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -1,21 +1,20 @@
 pub mod tokens;
 extern crate derive_more;
 
-use std::{fmt};
+use std::fmt;
 
 use crate::INTERNER;
 
 use lazy_static::lazy_static;
 
 use rksuid::rksuid;
-use string_interner::{DefaultSymbol};
-use tracing::{instrument};
+use string_interner::DefaultSymbol;
+use tracing::instrument;
 
 use self::tokens::{Token, TokenStream, TypedToken};
 
 lazy_static! {
     static ref ASTERISK: DefaultSymbol = INTERNER.write().get_or_intern_static("*");
-    
 }
 #[derive(Clone, Debug)]
 pub struct Record {

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -43,7 +43,7 @@ custom_derive! {
 }
 
 impl Grokker {
-    fn to_pattern(&self) -> String {
+    fn to_pattern(self) -> String {
         match self {
             Grokker::Base10Integer => r"(?:[+-]?(?:[0-9]+))".to_string(),
             Grokker::Base10Float => {
@@ -207,6 +207,10 @@ impl TokenStream {
 
     pub fn len(&self) -> usize {
         self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
     }
 
     pub fn get_token_at_index(&self, idx: usize) -> Option<Token> {

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -1,4 +1,4 @@
-use std::{fmt, collections::HashMap};
+use std::{collections::HashMap, fmt};
 
 use crate::INTERNER;
 use anyhow::Error;
@@ -15,7 +15,6 @@ lazy_static! {
     static ref MATCHERS: RegexSet = Grokker::build_pattern_set();
     static ref GROKKER_COUNT: usize = Grokker::iter_variants().count() - 1;
     static ref GROKKER_SYMS: HashMap<Grokker, DefaultSymbol> = symbolize_grokker();
-    
 }
 
 fn symbolize_grokker() -> HashMap<Grokker, DefaultSymbol> {
@@ -126,7 +125,9 @@ impl From<Token> for DefaultSymbol {
     fn from(tok: Token) -> DefaultSymbol {
         match tok {
             Token::Wildcard => *ASTERISK,
-            Token::TypedMatch(t) => *GROKKER_SYMS.get(&t).expect("every grokker must have a symbol"),
+            Token::TypedMatch(t) => *GROKKER_SYMS
+                .get(&t)
+                .expect("every grokker must have a symbol"),
             Token::Value(v) => match v {
                 TypedToken::String(s) => s,
                 TypedToken::Int(i) => INTERNER.write().get_or_intern(i.to_string()),
@@ -281,9 +282,7 @@ mod should {
     #[test]
     fn test_wildcard_lhs() {
         let lhs = Token::Wildcard;
-        let rhs = Token::Value(TypedToken::String(
-            INTERNER.write().get_or_intern("foo"),
-        ));
+        let rhs = Token::Value(TypedToken::String(INTERNER.write().get_or_intern("foo")));
         assert_that(&lhs).is_equal_to(rhs.clone());
         assert_that(&rhs).is_equal_to(lhs);
     }


### PR DESCRIPTION
Taking the chance to quickly setup some basic benchmarks and configure criterion as well as run the benchmarks on trunk with alert comments if there's a 200% regression or more.

Also snuck in a little functionality in `LogGroup::add_example` so that it now discovers and updates variables. This is a little dicey right now since variables do not get counted in scoring so if too many are matched right now it is possible that a line which should match suddenly will not once enough tokens have been extracted. Relatively soon this will be fixed when extracted variables become `TypedMatch` tokens  which can be scored.