### PR TITLE
Tokenization overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drain-flow"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -154,7 +154,6 @@ mod should {
     use proptest::prelude::*;
     use proptest::string::string_regex;
     use spectral::prelude::*;
-    use tracing_test::traced_test;
 
     prop_compose! {
         fn gen_word()(s in "[[:alpha:]]+") -> String {

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -8,7 +8,7 @@ use joinery::JoinableIterator;
 use lazy_static::lazy_static;
 use regex::RegexSet;
 use string_interner::DefaultSymbol;
-use tracing::{debug, info, instrument};
+use tracing::{debug, instrument};
 
 use super::ASTERISK;
 
@@ -183,7 +183,7 @@ impl TokenStream {
                 let token = (
                     Offset {
                         start: start.0,
-                        end: end,
+                        end,
                     },
                     Token::Value(TypedToken::String(interner.get_or_intern(w))),
                 );
@@ -233,16 +233,12 @@ impl fmt::Display for TokenStream {
             .iter()
             .tuple_windows()
             .map(|(first, second)| (first.0.end, second.0.start))
-            .map(|t| " ".repeat(t.1 - t.0).to_string())
+            .map(|t| " ".repeat(t.1 - t.0))
             .collect::<Vec<String>>();
         write!(
             f,
             "{}",
-            words
-                .iter()
-                .interleave(whitespace.iter())
-                .join_concat()
-                .to_string()
+            words.iter().interleave(whitespace.iter()).join_concat()
         )
     }
 }


### PR DESCRIPTION
This PR is a pretty substantial rework of tokenization of input lines to be significantly more compatible with unicode, with the major exception of continuing to use ASCII word boundaries since Unicode word boundaries are wildly complex and do the wrong thing on lots of common ASCII data (MAC addresses, in particular, do not play well with Unicode word splitting.)

One another notable improvement is that `fmt::Display for TokenStream` now reproduces whitespace quantities correctly ignoring leading and trailing space, i.e. "   the   white  dog jumped over the brown      fox       " when tokenized then stringified would yield "the   white  dog jumped over the brown      fox" as if it had been run through `trim()` first which ensures that the stringified form will always be at least a substring match of the original.

