### PR TITLE
Replace variable tokens in LogGroup base event

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drain-flow"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/benches/core_benchmarks.rs
+++ b/benches/core_benchmarks.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 extern crate serde_derive;
 extern crate tinytemplate;
 

--- a/benches/generators/mod.rs
+++ b/benches/generators/mod.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 
 use anyhow::Error;
-use chrono::{Duration, NaiveDateTime};
 use serde_derive::{Deserialize, Serialize};
-use serde_json::Result as serde_Result;
 use tinytemplate::TinyTemplate;
 
 #[derive(Serialize, Deserialize)]

--- a/benches/sink_benchmark.rs
+++ b/benches/sink_benchmark.rs
@@ -1,10 +1,8 @@
-use chrono::{DateTime, Utc};
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use drain_flow::log_group::LogGroup;
-use drain_flow::record::Record;
+use chrono::Utc;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
 use drain_flow::SimpleDrain;
 use generators::{RecordTemplate, Sendmail};
-use rand::prelude::*;
 
 use rand::Rng;
 

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -72,7 +72,6 @@ impl LogGroup {
             let (offset, _) = self.event.inner.inner[var.0].clone();
             self.event.inner.inner[var.0] = (offset, var.1);
         }
-        
     }
 
     #[instrument]

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -129,14 +129,15 @@ mod should {
 
     #[test]
     fn test_update_variables() {
-        let rec1 = Record::new("Common prefix Common prefix Common prefix 1234".to_string());
+        let r1 = Record::new("Common Prefix Common Prefix Common Prefix 6789".to_string());
+        let r2 = Record::new("Common Prefix Common Prefix Common Prefix 827364".to_string());
         let mut lg = LogGroup {
-            event: rec1.clone(),
-            examples: vec![rec1],
+            event: r1.clone(),
+            examples: vec![r1],
             variables: HashMap::new(),
         };
-        let rec2 = Record::new("Common prefix Common prefix Common prefix 3456".to_string());
-        let vars = lg.discover_variables(&rec2).unwrap();
+        
+        let vars = lg.discover_variables(&r2).unwrap();
         lg.updaate_variables(vars);
         assert_that(&lg.variables).contains_key(6);
     }

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -67,8 +67,12 @@ impl LogGroup {
     fn updaate_variables(&mut self, vars: Vec<(usize, Token)>) {
         for var in vars {
             // Assume we got vars from discover_variab les so it has already checked against this map
-            self.variables.insert(var.0, var.1);
+            self.variables.insert(var.0, var.1.clone());
+            // Update the tokens in the base event as well
+            let (offset, _) = self.event.inner.inner[var.0].clone();
+            self.event.inner.inner[var.0] = (offset, var.1);
         }
+        
     }
 
     #[instrument]

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -18,7 +18,7 @@ lazy_static! {
 }
 #[derive(Clone, Debug)]
 pub struct Record {
-    inner: TokenStream,
+    pub(crate) inner: TokenStream,
     pub uid: rksuid::Ksuid,
 }
 impl Record {

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -9,7 +9,7 @@ use lazy_static::lazy_static;
 
 use rksuid::rksuid;
 use string_interner::DefaultSymbol;
-use tracing::{info, instrument};
+use tracing::{debug, instrument};
 
 use self::tokens::{Token, TokenStream, TypedToken};
 
@@ -41,7 +41,7 @@ impl Record {
             .iter()
             .filter(|(this, other)| {
                 if this == other {
-                    info!("{}", format!("found match of {} and {}\n", this, other));
+                    debug!("{}", format!("found match of {} and {}\n", this, other));
                     true
                 } else {
                     false

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -163,7 +163,7 @@ pub struct Offset {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TokenStream {
-    inner: Vec<(Offset, Token)>,
+    pub(crate) inner: Vec<(Offset, Token)>,
 }
 
 impl TokenStream {


### PR DESCRIPTION
The main change here is updating the base event for a LogGroup when new variables are discovered. Also cleaned up a bunch of warnings from the benchmarks.