### PR TITLE
Customize instrument proc macros

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "drain-flow"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,7 @@ impl<'a> SimpleDrain {
         }
     }
 
-    #[instrument(skip(self),level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn iter_groups(&self) -> Vec<Vec<&LogGroup>> {
         let mut results: Vec<Vec<&LogGroup>> = Vec::new();
         for length in self.base_layer.keys() {
@@ -137,7 +137,7 @@ impl<'a> SimpleDrain {
         results
     }
 
-    #[instrument(skip(self),level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn resolve(&self, sym: DefaultSymbol) -> String {
         self.strings
             .read()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub struct SimpleDrain {
 }
 
 impl<'a> SimpleDrain {
-    #[instrument]
+    #[instrument(skip(domain))]
     pub fn new(domain: Vec<String>) -> Result<Self, Error> {
         let patterns = domain
             .iter()
@@ -48,7 +48,7 @@ impl<'a> SimpleDrain {
         })
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn set_threshold(&mut self, numerator: u64, denominator: u64) -> Result<(), Error> {
         let numer = BigInt::from_u64(numerator)
             .ok_or_else(|| anyhow!("unable to make numerator from {}", numerator))?;
@@ -65,7 +65,7 @@ impl<'a> SimpleDrain {
     /// Ok(true) when a new entry is added
     /// Ok(false) when the line matched an existing entry
     /// Err(e) for errors during processing
-    #[instrument]
+    #[instrument(skip(self, line))]
     pub fn process_line(&mut self, line: String) -> Result<bool, Error> {
         if line.is_empty() {
             return Ok(false);
@@ -122,7 +122,7 @@ impl<'a> SimpleDrain {
         }
     }
 
-    #[instrument]
+    #[instrument(skip(self),level="trace")]
     pub fn iter_groups(&self) -> Vec<Vec<&LogGroup>> {
         let mut results: Vec<Vec<&LogGroup>> = Vec::new();
         for length in self.base_layer.keys() {
@@ -137,7 +137,7 @@ impl<'a> SimpleDrain {
         results
     }
 
-    #[instrument]
+    #[instrument(skip(self),level="trace")]
     pub fn resolve(&self, sym: DefaultSymbol) -> String {
         self.strings
             .read()

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -34,7 +34,7 @@ impl LogGroup {
         }
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn event(&self) -> &Record {
         &self.event
     }
@@ -74,17 +74,17 @@ impl LogGroup {
         }
     }
 
-    #[instrument(level="trace")]
+    #[instrument(level = "trace")]
     pub fn len(&self) -> usize {
         self.examples.len()
     }
 
-    #[instrument(level="trace")]
+    #[instrument(level = "trace")]
     pub fn is_empty(&self) -> bool {
         self.examples.is_empty()
     }
 
-    #[instrument(level="info")]
+    #[instrument(level = "info")]
     pub fn get_examples(&self) -> Vec<Record> {
         self.examples.clone()
     }
@@ -136,7 +136,7 @@ mod should {
             examples: vec![r1],
             variables: HashMap::new(),
         };
-        
+
         let vars = lg.discover_variables(&r2).unwrap();
         lg.updaate_variables(vars);
         assert_that(&lg.variables).contains_key(6);

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -16,7 +16,7 @@ pub struct LogGroup {
 pub type Wildcard = (usize, Token);
 
 impl LogGroup {
-    #[instrument]
+    #[instrument(skip(event))]
     pub fn new(event: Record) -> Self {
         Self {
             event,
@@ -25,7 +25,7 @@ impl LogGroup {
         }
     }
 
-    #[instrument]
+    #[instrument(skip(self, rec))]
     pub fn add_example(&mut self, rec: Record) {
         let vars = self.discover_variables(&rec).unwrap();
         self.examples.push(rec);
@@ -34,12 +34,12 @@ impl LogGroup {
         }
     }
 
-    #[instrument]
+    #[instrument(skip(self), level="trace")]
     pub fn event(&self) -> &Record {
         &self.event
     }
 
-    #[instrument]
+    #[instrument(skip(self, rec))]
     pub fn discover_variables(&self, rec: &Record) -> Result<Vec<Wildcard>, Error> {
         let f = self
             .event
@@ -63,7 +63,7 @@ impl LogGroup {
         Ok(f)
     }
 
-    #[instrument]
+    #[instrument(skip(self, vars))]
     fn updaate_variables(&mut self, vars: Vec<(usize, Token)>) {
         for var in vars {
             // Assume we got vars from discover_variab les so it has already checked against this map
@@ -74,17 +74,17 @@ impl LogGroup {
         }
     }
 
-    #[instrument]
+    #[instrument(level="trace")]
     pub fn len(&self) -> usize {
         self.examples.len()
     }
 
-    #[instrument]
+    #[instrument(level="trace")]
     pub fn is_empty(&self) -> bool {
         self.examples.is_empty()
     }
 
-    #[instrument]
+    #[instrument(level="info")]
     pub fn get_examples(&self) -> Vec<Record> {
         self.examples.clone()
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -22,7 +22,7 @@ pub struct Record {
     pub uid: rksuid::Ksuid,
 }
 impl Record {
-    #[instrument]
+    #[instrument(name = "Create new record", skip(line), level = "trace")]
     pub fn new(line: String) -> Self {
         Self {
             inner: TokenStream::from_unicode_line(&line),
@@ -30,7 +30,7 @@ impl Record {
         }
     }
 
-    // #[instrument]
+    #[instrument(name = "Calculate similarity score", skip(candidate, self))]
     pub fn calc_sim_score(&self, candidate: &Record) -> u64 {
         let pairs = self
             .into_iter()
@@ -51,21 +51,22 @@ impl Record {
         score
     }
 
-    #[instrument]
+    #[instrument(level="trace", skip(self))]
     pub fn first(&self) -> Option<DefaultSymbol> {
         self.inner.first().map(|f| f.into())
     }
 
-    #[instrument]
+    #[instrument(skip(self), level="trace")]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
+    #[instrument(skip(self), level="trace")]
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
 
-    #[instrument]
+    #[instrument(skip(sym), level="trace")]
     pub fn resolve(sym: DefaultSymbol) -> Option<String> {
         INTERNER.read().resolve(sym).map(|s| s.to_owned())
     }
@@ -171,8 +172,6 @@ mod should {
             string_regex(r"((([0-9A-Fa-f]{1,4}:){7}([0-9A-Fa-f]{1,4}|:))|(([0-9A-Fa-f]{1,4}:){6}(:[0-9A-Fa-f]{1,4}|((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){5}(((:[0-9A-Fa-f]{1,4}){1,2})|:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3})|:))|(([0-9A-Fa-f]{1,4}:){4}(((:[0-9A-Fa-f]{1,4}){1,3})|((:[0-9A-Fa-f]{1,4})?:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){3}(((:[0-9A-Fa-f]{1,4}){1,4})|((:[0-9A-Fa-f]{1,4}){0,2}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){2}(((:[0-9A-Fa-f]{1,4}){1,5})|((:[0-9A-Fa-f]{1,4}){0,3}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(([0-9A-Fa-f]{1,4}:){1}(((:[0-9A-Fa-f]{1,4}){1,6})|((:[0-9A-Fa-f]{1,4}){0,4}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:))|(:(((:[0-9A-Fa-f]{1,4}){1,7})|((:[0-9A-Fa-f]{1,4}){0,5}:((25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)(\.(25[0-5]|2[0-4]\d|1\d\d|[1-9]?\d)){3}))|:)))").unwrap(),
             // Base 10 Integer
             string_regex(r"(?:[+-]?(?:[0-9]+))").unwrap(),
-            // Months, too flaky to use yet becasue not enough possible values
-            // string_regex(r"(?:[Jj]an(?:uary|uar)?|[Ff]eb(?:ruary|ruar)?|[Mm](?:a|ä)?r(?:ch|z)?|[Aa]pr(?:il)?|[Mm]a(?:y|i)?|[Jj]un(?:e|i)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo](?:c|k)?t(?:ober)?|[Nn]ov(?:ember)?|[Dd]e(?:c|z)(?:ember)?)").unwrap(),
         ]
     }
 

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -51,22 +51,22 @@ impl Record {
         score
     }
 
-    #[instrument(level="trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     pub fn first(&self) -> Option<DefaultSymbol> {
         self.inner.first().map(|f| f.into())
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
 
-    #[instrument(skip(sym), level="trace")]
+    #[instrument(skip(sym), level = "trace")]
     pub fn resolve(sym: DefaultSymbol) -> Option<String> {
         INTERNER.read().resolve(sym).map(|s| s.to_owned())
     }

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -85,7 +85,7 @@ impl Grokker {
         RegexSet::new(variants).expect("valid regular expressions compile")
     }
 
-    #[instrument(level="trace")]
+    #[instrument(level = "trace")]
     pub fn from_match_index(idx: usize) -> Option<Grokker> {
         if idx > *GROKKER_COUNT {
             return None;
@@ -196,7 +196,7 @@ impl TokenStream {
         Self { inner: words }
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn first(&self) -> Option<Token> {
         match self.inner.len() {
             0 => None,
@@ -204,12 +204,12 @@ impl TokenStream {
         }
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    #[instrument(skip(self), level="trace")]
+    #[instrument(skip(self), level = "trace")]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }

--- a/src/record/tokens.rs
+++ b/src/record/tokens.rs
@@ -85,6 +85,7 @@ impl Grokker {
         RegexSet::new(variants).expect("valid regular expressions compile")
     }
 
+    #[instrument(level="trace")]
     pub fn from_match_index(idx: usize) -> Option<Grokker> {
         if idx > *GROKKER_COUNT {
             return None;
@@ -167,6 +168,7 @@ pub struct TokenStream {
 }
 
 impl TokenStream {
+    #[instrument(skip(line))]
     pub fn from_unicode_line(line: &str) -> Self {
         let mut interner = INTERNER.write();
         let mut progress = 0usize;
@@ -194,7 +196,7 @@ impl TokenStream {
         Self { inner: words }
     }
 
-    #[instrument]
+    #[instrument(skip(self), level="trace")]
     pub fn first(&self) -> Option<Token> {
         match self.inner.len() {
             0 => None,
@@ -202,17 +204,17 @@ impl TokenStream {
         }
     }
 
-    #[instrument]
+    #[instrument(skip(self), level="trace")]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    #[instrument]
+    #[instrument(skip(self), level="trace")]
     pub fn is_empty(&self) -> bool {
         self.inner.is_empty()
     }
 
-    #[instrument]
+    #[instrument(skip(self))]
     pub fn get_token_at_index(&self, idx: usize) -> Option<Token> {
         match idx < self.inner.len() {
             true => Some(self.inner[idx].1.clone()),


### PR DESCRIPTION
Using the `tracing::instrument` procedural macro without args was producing way too much data so this PR adds skipping of almost all params on functions, especially `self` on the struct types which was causing ridiculous amounts of data to be logged.