### PR TITLE
Tweak tracing setup

### DIFF
--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -26,7 +26,7 @@ impl fmt::Display for Wildcard {
 }
 
 impl LogGroup {
-    #[instrument(skip(event))]
+    #[instrument(level = "trace", skip(event))]
     pub fn new(event: Record) -> Self {
         Self {
             id: event.uid,
@@ -36,7 +36,7 @@ impl LogGroup {
         }
     }
 
-    #[instrument(skip(self, rec))]
+    #[instrument(level = "trace", skip(self, rec))]
     pub fn add_example(&mut self, rec: Record) {
         let vars = self.discover_variables(&rec).unwrap();
         self.examples.push(rec);
@@ -45,13 +45,13 @@ impl LogGroup {
         }
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     pub fn event(&self) -> &Record {
         &self.event
     }
 
     /// Compare a record with this log group and identify positions which qualify as variables, returned as vector of [Wildcard]
-    #[instrument(skip(self, rec))]
+    #[instrument(level = "trace", skip(self, rec))]
     pub fn discover_variables(&self, rec: &Record) -> Result<Vec<Wildcard>, Error> {
         let f = self
             .event
@@ -75,7 +75,7 @@ impl LogGroup {
         Ok(f)
     }
 
-    #[instrument(skip(self, vars))]
+    #[instrument(level = "trace", skip(self, vars))]
     fn updaate_variables(&mut self, vars: Vec<Wildcard>) {
         for var in vars {
             // Assume we got vars from discover_variab les so it has already checked against this map
@@ -87,29 +87,31 @@ impl LogGroup {
     }
 
     /// Number of examples this [LogGroup] contains
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip_all)]
     pub fn len(&self) -> usize {
         self.examples.len()
     }
 
     /// Whether any examples exist for a [LogGroup]
-    #[instrument(level = "trace")]
+    #[instrument(level = "trace", skip_all)]
     pub fn is_empty(&self) -> bool {
         self.examples.is_empty()
     }
 
     /// Return a Vec<&Record> of the example records for this group
-    #[instrument(level = "info")]
+    #[instrument(level = "trace", skip_all)]
     pub fn get_examples(&self) -> Vec<&Record> {
         self.examples.iter().collect::<Vec<&Record>>()
     }
 
     /// Returns the [Ksuid] associated with the [LogGroup], usually identical to the [Record] which created the group
+    #[instrument(level = "trace", skip_all)]
     pub fn get_id(&self) -> Ksuid {
         self.id
     }
 
     /// Returns the [DateTime] of the creation of the base event in the [LogGroup]
+    #[instrument(level = "trace", skip_all)]
     pub fn get_time(&self) -> DateTime<Utc> {
         self.event.uid.get_time()
     }

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -22,7 +22,7 @@ pub struct Record {
     pub uid: Ksuid,
 }
 impl Record {
-    #[instrument(name = "Create new record", skip(line), level = "trace")]
+    #[instrument(name = "Create new record", level = "trace", skip(line))]
     pub fn new(line: String) -> Self {
         Self {
             inner: TokenStream::from_unicode_line(&line),
@@ -30,7 +30,7 @@ impl Record {
         }
     }
 
-    #[instrument(name = "Calculate similarity score", skip(candidate, self))]
+    #[instrument(name = "Calculate similarity score", level = "trace", skip(candidate, self))]
     pub fn calc_sim_score(&self, candidate: &Record) -> u64 {
         let pairs = self
             .into_iter()
@@ -55,17 +55,17 @@ impl Record {
         self.inner.first().map(|f| f.into())
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     pub fn len(&self) -> usize {
         self.inner.len()
     }
 
-    #[instrument(skip(self), level = "trace")]
+    #[instrument(level = "trace", skip(self))]
     pub fn is_empty(&self) -> bool {
         self.inner.len() == 0
     }
 
-    #[instrument(skip(sym), level = "trace")]
+    #[instrument(level = "trace")]
     pub fn resolve(sym: DefaultSymbol) -> Option<String> {
         INTERNER.read().resolve(sym).map(|s| s.to_owned())
     }
@@ -101,7 +101,7 @@ impl Iterator for RecordIntoIter {
                     TypedToken::Float(f) => f.to_string(),
                 },
             },
-            None => todo!(),
+            None => unreachable!(),
         };
 
         self.index += 1;

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -30,7 +30,11 @@ impl Record {
         }
     }
 
-    #[instrument(name = "Calculate similarity score", level = "trace", skip(candidate, self))]
+    #[instrument(
+        name = "Calculate similarity score",
+        level = "trace",
+        skip(candidate, self)
+    )]
     pub fn calc_sim_score(&self, candidate: &Record) -> u64 {
         let pairs = self
             .into_iter()


### PR DESCRIPTION
The tracing logs were a little noisy, this change pushes them all to the `trace` severity and ignores virtually all arguments.