### PR TITLE
feat: Implement LogQL range aggregation and drain benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ parking_lot = { version = "0.12.1", features = [
 ] }
 regex = "1.6.0"
 spectral = "0.6.0"
-uuid = { version = "1.0", features = ["v4"] }
+uuid = { version = "1.0", features = ["v4", "v1"] }
 string-interner = "0.19.0"
 tracing = "0.1.36"
 
@@ -48,4 +48,8 @@ harness = false
 
 [[bench]]
 name = "two_stage_drain_integration_test"
+harness = false
+
+[[bench]]
+name = "drain_benchmarks"
 harness = false

--- a/benches/drain_benchmarks.rs
+++ b/benches/drain_benchmarks.rs
@@ -1,0 +1,261 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use drain_flow::{
+    drains::{simple::SingleLayer, two_stage_drain::TwoStageDrain},
+    log_group::LogGroup,
+    query::{query_log_range_aggregation, LogStore},
+    // record::Record, // Removed as it's unused directly in this file
+};
+use chrono::{Utc, Duration as ChronoDuration};
+// use rand::distributions::Alphanumeric; // Removed problematic import
+use rand::{Rng, SeedableRng};
+use rand::rngs::StdRng;
+// use std::{thread::sleep, time::Duration as StdDuration}; // Removed as sleep is not used here
+
+mod generators;
+use generators::{LogGenerator, RecordTemplate, Sendmail};
+
+fn generate_log_lines(count: usize, seed: u64) -> Vec<String> {
+    let mut rng = StdRng::seed_from_u64(seed);
+    let log_generator = LogGenerator::new().expect("Failed to create LogGenerator");
+    let base_time = Utc::now();
+    let mut lines = Vec::with_capacity(count);
+
+    for i in 0..count {
+        let current_time = base_time + ChronoDuration::milliseconds(i as i64);
+        // Add some random variation to status and message to create more diverse log groups
+        let status: usize = rng.gen_range(200..600);
+        let message_length: usize = rng.gen_range(5..20);
+        const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
+                                abcdefghijklmnopqrstuvwxyz\
+                                0123456789";
+        let message: String = (0..message_length)
+            .map(|_| {
+                let idx = rng.gen_range(0..CHARSET.len());
+                CHARSET[idx] as char
+            })
+            .collect();
+        
+        let template = RecordTemplate::Sendmail(Sendmail {
+            ts: current_time.to_rfc3339(),
+            remote: format!("host{}.example.com", rng.gen_range(1..100)),
+            status,
+            message,
+        });
+        lines.push(log_generator.make_record(template));
+    }
+    lines
+}
+
+// --- SingleLayer Benchmarks ---
+
+fn benchmark_single_layer_process_line(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SingleLayer_ProcessLine");
+    let line_counts = [100, 1000, 5000];
+    let seed = 42; // For reproducibility
+
+    for count in line_counts.iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
+            let lines = generate_log_lines(size, seed);
+            let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+            b.iter(|| {
+                for line in &lines {
+                    drain.process_line(black_box(line.clone())).unwrap();
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_log_store_from_single_layer(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SingleLayer_LogStorePopulation");
+    let line_counts = [100, 1000, 5000];
+    let seed = 42;
+
+    for count in line_counts.iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
+            let lines = generate_log_lines(size, seed);
+            b.iter(|| {
+                let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+                for line in &lines {
+                    drain.process_line(line.clone()).unwrap();
+                }
+                let log_groups_nested: Vec<Vec<&LogGroup>> = drain.iter_groups(); // Removed .collect()
+                let log_groups: Vec<LogGroup> = log_groups_nested
+                    .into_iter()
+                    .flatten()
+                    .map(|lg_ref| lg_ref.clone()) // Clone to get owned LogGroup
+                    .collect();
+                let _store = LogStore::from_log_groups(black_box(log_groups));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
+    let mut group = c.benchmark_group("SingleLayer_Query");
+    let line_count = 2000;
+    let seed = 42;
+    let lines = generate_log_lines(line_count, seed);
+
+    let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+    for line in &lines {
+        drain.process_line(line.clone()).unwrap();
+    }
+    let log_groups_nested: Vec<Vec<&LogGroup>> = drain.iter_groups(); // Removed .collect()
+    let log_groups: Vec<LogGroup> = log_groups_nested
+        .into_iter()
+        .flatten()
+        .map(|lg_ref| lg_ref.clone())
+        .collect();
+    let store = LogStore::from_log_groups(log_groups);
+
+    // Find a group with examples for querying
+    let target_group_id_opt = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
+        .iter()
+        .find(|lg| !lg.get_examples().is_empty())
+        .map(|lg| lg.id);
+    
+    if target_group_id_opt.is_none() {
+        println!("Warning: No suitable LogGroup with examples found for single_layer query benchmark. Skipping.");
+        return;
+    }
+    let target_group_id = target_group_id_opt.unwrap();
+
+    let base_time = Utc::now() - ChronoDuration::milliseconds(line_count as i64 / 2); // Middle of generated time range
+
+    let time_ranges = [
+        (base_time - ChronoDuration::milliseconds(500), base_time + ChronoDuration::milliseconds(500)), // 1s window
+        (base_time - ChronoDuration::milliseconds(100), base_time + ChronoDuration::milliseconds(100)), // 200ms window
+        (base_time, base_time + ChronoDuration::milliseconds(50)), // 50ms window
+    ];
+
+    for (idx, (start_time, end_time)) in time_ranges.iter().enumerate() {
+        group.bench_with_input(
+            BenchmarkId::new("QueryTimeRange", format!("Range{}", idx)),
+            &(*start_time, *end_time),
+            |b, &(s, e)| {
+                b.iter(|| {
+                    query_log_range_aggregation(black_box(&store), black_box(target_group_id), black_box(s), black_box(e));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+
+// --- TwoStageDrain Benchmarks ---
+
+fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TwoStageDrain_ProcessLine");
+    let line_counts = [100, 1000, 5000];
+    let seed = 42;
+
+    for count in line_counts.iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
+            let lines = generate_log_lines(size, seed);
+            // Default params: domain_regex_strings: vec![], threshold: 0.5, max_depth: 4, max_children: 10
+            let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain"); 
+            b.iter(|| {
+                for line in &lines {
+                    drain.process_line(black_box(line.clone())).unwrap();
+                }
+            });
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_log_store_from_two_stage_drain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TwoStageDrain_LogStorePopulation");
+    let line_counts = [100, 1000, 5000];
+    let seed = 42;
+
+    for count in line_counts.iter() {
+        group.throughput(Throughput::Elements(*count as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
+            let lines = generate_log_lines(size, seed);
+            b.iter(|| {
+                let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
+                for line in &lines {
+                    drain.process_line(line.clone()).unwrap();
+                }
+                let log_groups: Vec<LogGroup> = drain.collect_all_log_groups(); // Using the new method
+                let _store = LogStore::from_log_groups(black_box(log_groups));
+            });
+        });
+    }
+    group.finish();
+}
+
+fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
+    let mut group = c.benchmark_group("TwoStageDrain_Query");
+    let line_count = 2000;
+    let seed = 42;
+    let lines = generate_log_lines(line_count, seed);
+
+    let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
+    for line in &lines {
+        drain.process_line(line.clone()).unwrap();
+    }
+    let log_groups = drain.collect_all_log_groups();
+    let store = LogStore::from_log_groups(log_groups);
+
+    let target_group_id_opt = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
+        .iter()
+        .find(|lg| !lg.get_examples().is_empty())
+        .map(|lg| lg.id);
+
+    if target_group_id_opt.is_none() {
+        println!("Warning: No suitable LogGroup with examples found for two_stage_drain query benchmark. Skipping.");
+        return;
+    }
+    let target_group_id = target_group_id_opt.unwrap();
+    
+    let base_time = Utc::now() - ChronoDuration::milliseconds(line_count as i64 / 2);
+
+    let time_ranges = [
+        (base_time - ChronoDuration::milliseconds(500), base_time + ChronoDuration::milliseconds(500)),
+        (base_time - ChronoDuration::milliseconds(100), base_time + ChronoDuration::milliseconds(100)),
+        (base_time, base_time + ChronoDuration::milliseconds(50)),
+    ];
+
+    for (idx, (start_time, end_time)) in time_ranges.iter().enumerate() {
+        group.bench_with_input(
+            BenchmarkId::new("QueryTimeRange", format!("Range{}", idx)),
+            &(*start_time, *end_time),
+            |b, &(s, e)| {
+                b.iter(|| {
+                    query_log_range_aggregation(black_box(&store), black_box(target_group_id), black_box(s), black_box(e));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_single_layer_process_line,
+    benchmark_log_store_from_single_layer,
+    benchmark_query_on_single_layer_data,
+    benchmark_two_stage_drain_process_line,
+    benchmark_log_store_from_two_stage_drain,
+    benchmark_query_on_two_stage_drain_data
+);
+criterion_main!(benches);

--- a/benches/drain_benchmarks.rs
+++ b/benches/drain_benchmarks.rs
@@ -8,6 +8,7 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
+use chrono::{Duration as ChronoDuration, Utc};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use drain_flow::{
     drains::{simple::SingleLayer, two_stage_drain::TwoStageDrain},
@@ -15,10 +16,9 @@ use drain_flow::{
     query::{query_log_range_aggregation, LogStore},
     // record::Record, // Removed as it's unused directly in this file
 };
-use chrono::{Utc, Duration as ChronoDuration};
 // use rand::distributions::Alphanumeric; // Removed problematic import
-use rand::{Rng, SeedableRng};
 use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 // use std::{thread::sleep, time::Duration as StdDuration}; // Removed as sleep is not used here
 
 mod generators;
@@ -44,7 +44,7 @@ fn generate_log_lines(count: usize, seed: u64) -> Vec<String> {
                 CHARSET[idx] as char
             })
             .collect();
-        
+
         let template = RecordTemplate::Sendmail(Sendmail {
             ts: current_time.to_rfc3339(),
             remote: format!("host{}.example.com", rng.gen_range(1..100)),
@@ -88,7 +88,8 @@ fn benchmark_log_store_from_single_layer(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
             let lines = generate_log_lines(size, seed);
             b.iter(|| {
-                let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+                let mut drain =
+                    SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
                 for line in &lines {
                     drain.process_line(line.clone()).unwrap();
                 }
@@ -124,11 +125,12 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
     let store = LogStore::from_log_groups(log_groups);
 
     // Find a group with examples for querying
-    let target_group_id_opt = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
+    let target_group_id_opt = store
+        .get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
         .iter()
         .find(|lg| !lg.get_examples().is_empty())
         .map(|lg| lg.id);
-    
+
     if target_group_id_opt.is_none() {
         println!("Warning: No suitable LogGroup with examples found for single_layer query benchmark. Skipping.");
         return;
@@ -138,8 +140,14 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
     let base_time = Utc::now() - ChronoDuration::milliseconds(line_count as i64 / 2); // Middle of generated time range
 
     let time_ranges = [
-        (base_time - ChronoDuration::milliseconds(500), base_time + ChronoDuration::milliseconds(500)), // 1s window
-        (base_time - ChronoDuration::milliseconds(100), base_time + ChronoDuration::milliseconds(100)), // 200ms window
+        (
+            base_time - ChronoDuration::milliseconds(500),
+            base_time + ChronoDuration::milliseconds(500),
+        ), // 1s window
+        (
+            base_time - ChronoDuration::milliseconds(100),
+            base_time + ChronoDuration::milliseconds(100),
+        ), // 200ms window
         (base_time, base_time + ChronoDuration::milliseconds(50)), // 50ms window
     ];
 
@@ -149,14 +157,18 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
             &(*start_time, *end_time),
             |b, &(s, e)| {
                 b.iter(|| {
-                    query_log_range_aggregation(black_box(&store), black_box(target_group_id), black_box(s), black_box(e));
+                    query_log_range_aggregation(
+                        black_box(&store),
+                        black_box(target_group_id),
+                        black_box(s),
+                        black_box(e),
+                    );
                 });
             },
         );
     }
     group.finish();
 }
-
 
 // --- TwoStageDrain Benchmarks ---
 
@@ -170,7 +182,8 @@ fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
             let lines = generate_log_lines(size, seed);
             // Default params: domain_regex_strings: vec![], threshold: 0.5, max_depth: 4, max_children: 10
-            let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain"); 
+            let mut drain =
+                TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
             b.iter(|| {
                 for line in &lines {
                     drain.process_line(black_box(line.clone())).unwrap();
@@ -191,7 +204,8 @@ fn benchmark_log_store_from_two_stage_drain(c: &mut Criterion) {
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
             let lines = generate_log_lines(size, seed);
             b.iter(|| {
-                let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
+                let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100)
+                    .expect("Failed to create TwoStageDrain");
                 for line in &lines {
                     drain.process_line(line.clone()).unwrap();
                 }
@@ -209,14 +223,16 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
     let seed = 42;
     let lines = generate_log_lines(line_count, seed);
 
-    let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
+    let mut drain =
+        TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
     for line in &lines {
         drain.process_line(line.clone()).unwrap();
     }
     let log_groups = drain.collect_all_log_groups();
     let store = LogStore::from_log_groups(log_groups);
 
-    let target_group_id_opt = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
+    let target_group_id_opt = store
+        .get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
         .iter()
         .find(|lg| !lg.get_examples().is_empty())
         .map(|lg| lg.id);
@@ -226,12 +242,18 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
         return;
     }
     let target_group_id = target_group_id_opt.unwrap();
-    
+
     let base_time = Utc::now() - ChronoDuration::milliseconds(line_count as i64 / 2);
 
     let time_ranges = [
-        (base_time - ChronoDuration::milliseconds(500), base_time + ChronoDuration::milliseconds(500)),
-        (base_time - ChronoDuration::milliseconds(100), base_time + ChronoDuration::milliseconds(100)),
+        (
+            base_time - ChronoDuration::milliseconds(500),
+            base_time + ChronoDuration::milliseconds(500),
+        ),
+        (
+            base_time - ChronoDuration::milliseconds(100),
+            base_time + ChronoDuration::milliseconds(100),
+        ),
         (base_time, base_time + ChronoDuration::milliseconds(50)),
     ];
 
@@ -241,7 +263,12 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
             &(*start_time, *end_time),
             |b, &(s, e)| {
                 b.iter(|| {
-                    query_log_range_aggregation(black_box(&store), black_box(target_group_id), black_box(s), black_box(e));
+                    query_log_range_aggregation(
+                        black_box(&store),
+                        black_box(target_group_id),
+                        black_box(s),
+                        black_box(e),
+                    );
                 });
             },
         );

--- a/benches/generators/mod.rs
+++ b/benches/generators/mod.rs
@@ -15,7 +15,7 @@ use serde_derive::{Deserialize, Serialize};
 use tinytemplate::TinyTemplate;
 
 #[derive(Serialize, Deserialize)]
-pub(crate) enum RecordTemplate {
+pub enum RecordTemplate {
     Json(Json),
     NGINXAccess(NGINXAccess),
     Qmail(Qmail),
@@ -25,7 +25,7 @@ pub(crate) enum RecordTemplate {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct Json {
+pub struct Json {
     pub event_type: String,
     pub callsite: String,
     pub app_name: String,
@@ -33,7 +33,7 @@ pub(crate) struct Json {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct NGINXAccess {
+pub struct NGINXAccess {
     pub ts: String,
     pub client: String,
     pub method: String,
@@ -43,10 +43,10 @@ pub(crate) struct NGINXAccess {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct Qmail;
+pub struct Qmail;
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct Sendmail {
+pub struct Sendmail {
     pub ts: String,
     pub remote: String,
     pub status: usize,
@@ -54,7 +54,7 @@ pub(crate) struct Sendmail {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct SlowQuery {
+pub struct SlowQuery {
     pub ts: String,
     pub db: String,
     pub op: String,
@@ -65,7 +65,7 @@ pub(crate) struct SlowQuery {
 }
 
 #[derive(Serialize, Deserialize)]
-pub(crate) struct Syslog {
+pub struct Syslog {
     pub ts: String,
     pub facility: String,
     pub severity: String,
@@ -78,7 +78,7 @@ const SENDMAIL_TEMPLATE: &str =
 const SLOW_QUERY_TEMPLATE: &str = "{ foo }";
 const SYSLOG_TEMPLATE: &str = "{ foo }";
 
-pub(crate) struct LogGenerator<'a> {
+pub struct LogGenerator<'a> {
     tiny: TinyTemplate<'a>,
 }
 
@@ -93,7 +93,7 @@ impl LogGenerator<'_> {
         Ok(Self { tiny: tt })
     }
 
-    pub(crate) fn make_record(&self, template: RecordTemplate) -> String {
+    pub fn make_record(&self, template: RecordTemplate) -> String {
         match template {
             RecordTemplate::Json(j) => serde_json::to_string(&j).expect(""),
             RecordTemplate::NGINXAccess(n) => self.tiny.render("nginx", &n).expect(""),

--- a/benches/two_stage_drain_integration_test.rs
+++ b/benches/two_stage_drain_integration_test.rs
@@ -8,8 +8,8 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
-use drain_flow::drains::two_stage_drain::TwoStageDrain; // Adjust path if necessary
 use anyhow::Result;
+use drain_flow::drains::two_stage_drain::TwoStageDrain; // Adjust path if necessary
 
 fn básico_drain_test_harness(lines: Vec<String>, expected_groups: usize) -> Result<()> {
     let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10)?; // Using default values for now
@@ -26,7 +26,10 @@ fn básico_drain_test_harness(lines: Vec<String>, expected_groups: usize) -> Res
     // Add a TODO comment here.
     // TODO: Implement a way to count log groups in TwoStageDrain and assert against expected_groups.
     // For now, the test just ensures processing doesn't panic.
-    println!("Processed {} lines. Expected {} groups. (Verification pending iter_groups)", drain.line_count_processed, expected_groups); // Placeholder for line_count
+    println!(
+        "Processed {} lines. Expected {} groups. (Verification pending iter_groups)",
+        drain.line_count_processed, expected_groups
+    ); // Placeholder for line_count
 
     Ok(())
 }
@@ -60,22 +63,22 @@ fn test_basic_drain_integration_with_preprocessing() -> Result<()> {
     let mut drain = TwoStageDrain::new(
         vec![
             r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z".to_string(), // ISO8601 Timestamp
-            r"user-\d+".to_string() // User ID
+            r"user-\d+".to_string(),                             // User ID
         ],
         0.6, // Slightly higher threshold
         5,   // Max depth
-        100  // Max children (less restrictive for this test)
+        100, // Max children (less restrictive for this test)
     )?;
 
     let lines = vec![
         "2023-10-27T10:00:00Z user-123 System started successfully".to_string(),
         "2023-10-27T10:01:15Z user-456 System started successfully".to_string(), // Match 1 (vars: date, user)
-        "2023-10-27T10:02:30Z user-123 System shutdown initiated".to_string(),  // New group
+        "2023-10-27T10:02:30Z user-123 System shutdown initiated".to_string(),   // New group
         "2023-10-27T10:03:00Z user-789 System started successfully".to_string(), // Match 1
-        "2023-10-27T10:04:00Z user-456 System shutdown initiated".to_string(),  // Match 2
+        "2023-10-27T10:04:00Z user-456 System shutdown initiated".to_string(),   // Match 2
         "2023-10-27T10:05:00Z user-123 System started successfully".to_string(), // Match 1
     ];
-    
+
     for line in lines {
         drain.process_line(line)?;
     }

--- a/benches/two_stage_drain_integration_test.rs
+++ b/benches/two_stage_drain_integration_test.rs
@@ -31,6 +31,13 @@ fn básico_drain_test_harness(lines: Vec<String>, expected_groups: usize) -> Res
     Ok(())
 }
 
+fn main() {
+    // This benchmark is intended to be run with `cargo test --bench two_stage_drain_integration_test`
+    // or by directly invoking test functions if used as a library.
+    // Adding a dummy main for `harness = false` when `cargo check --benches` is run.
+    println!("Run tests in this file using `cargo test --benches` or specific test invocation.");
+}
+
 #[test]
 fn test_basic_drain_integration_simple_lines() -> Result<()> {
     let lines = vec![

--- a/src/drains/two_stage_drain.rs
+++ b/src/drains/two_stage_drain.rs
@@ -293,20 +293,34 @@ impl TwoStageDrain {
     ) {
         match node.kind {
             NodeKind::Leaf(ref mut groups) => {
+                // This method is used when restructuring the tree (e.g. internal to leaf).
+                // It takes ownership of the groups. For benchmarking, we need clones.
                 all_log_groups.append(&mut std::mem::take(groups));
             }
             NodeKind::Internal(ref mut children_map) => {
                 for child_node in children_map.values_mut() {
-                    // Note: Recursive call needs to be Self:: or TwoStageDrain:: if it's a static method
-                    // For now, assuming it's made a free function or handled appropriately.
-                    // If it remains an instance method (even without using &self), this call needs care.
-                    // Let's assume it's called as a static-like method or free function for now.
                     Self::collect_log_groups_from_node(child_node, all_log_groups);
                 }
             }
         }
     }
 
+    // New recursive helper for collect_all_log_groups (read-only traversal)
+    fn collect_groups_recursive(node: &Node, collected_groups: &mut Vec<LogGroup>) {
+        match &node.kind {
+            NodeKind::Leaf(groups) => {
+                for group in groups {
+                    collected_groups.push(group.clone());
+                }
+            }
+            NodeKind::Internal(children_map) => {
+                for child_node in children_map.values() {
+                    Self::collect_groups_recursive(child_node, collected_groups);
+                }
+            }
+        }
+    }
+    
     // get_or_create_log_group_mut no longer needs &mut self
     // It operates on current_node and global INTERNER, and parameters.
     // However, to be callable from process_line which has &mut self,
@@ -575,5 +589,13 @@ impl TwoStageDrain {
         );
         log_groups_vec_for_new.push(LogGroup::new(new_record)); // new_record is moved here
         Ok(true) // Created new group
+    }
+
+    pub fn collect_all_log_groups(&self) -> Vec<LogGroup> {
+        let mut all_groups = Vec::new();
+        for node in self.tree.values() {
+            Self::collect_groups_recursive(node, &mut all_groups);
+        }
+        all_groups
     }
 }

--- a/src/drains/two_stage_drain.rs
+++ b/src/drains/two_stage_drain.rs
@@ -11,23 +11,22 @@
 use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Error};
-use uuid::Uuid;
 use fraction::{BigInt, Ratio}; // Removed ToPrimitive
 use lazy_static::lazy_static;
 use parking_lot::RwLock;
 use regex::Regex;
 use string_interner::{DefaultSymbol, StringInterner};
+use uuid::Uuid;
 
 use crate::log_group::LogGroup;
 use crate::record::Record;
 // Removed: use crate::record::tokens::ASTERISK;
 
 // Use the shared interner from simple.rs
-use crate::drains::simple; 
+use crate::drains::simple;
 
 lazy_static! {
-    static ref DRAIN_ASTERISK: DefaultSymbol =
-        simple::INTERNER.write().get_or_intern_static("<*>");
+    static ref DRAIN_ASTERISK: DefaultSymbol = simple::INTERNER.write().get_or_intern_static("<*>");
 }
 
 #[derive(Debug, Clone)]
@@ -115,10 +114,8 @@ mod tests {
     fn test_process_line_creates_second_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
         let _ = drain.process_line("Log message type A value1".to_string());
-        assert_that(
-            &drain.process_line("Completely different log message valueX".to_string()),
-        )
-        .is_ok_containing(true);
+        assert_that(&drain.process_line("Completely different log message valueX".to_string()))
+            .is_ok_containing(true);
     }
 
     #[traced_test]
@@ -223,8 +220,10 @@ impl TwoStageDrain {
                 // Path 2: Attempt to follow wildcard token <*> in the tree,
                 // but only if it's different from the specific token path (or if specific token is not a wildcard)
                 // This check avoids double-counting if record_tokens[current_depth] is already DRAIN_ASTERISK
-                let specific_token_is_wildcard = next_log_token_opt.map_or(false, |t| *t == *DRAIN_ASTERISK);
-                if !specific_token_is_wildcard { // only try wildcard if specific token wasn't already the wildcard
+                let specific_token_is_wildcard =
+                    next_log_token_opt.map_or(false, |t| *t == *DRAIN_ASTERISK);
+                if !specific_token_is_wildcard {
+                    // only try wildcard if specific token wasn't already the wildcard
                     if let Some(wildcard_child_node) = children_map.get(&*DRAIN_ASTERISK) {
                         let mut next_path_wildcard = current_path.clone();
                         next_path_wildcard.push(*DRAIN_ASTERISK);
@@ -246,19 +245,26 @@ impl TwoStageDrain {
                     }
                 }
 
-
                 // Condition for collecting all subtree groups (DRAIN paper Step 2 adjustment)
                 // If traversal for the current log's token sequence stops at this internal node
                 // (i.e., neither the specific next token nor a wildcard led further down this path for *this sequence*)
                 // then collect all groups under this node.
                 // This implies next_log_token_opt.is_some() because we are at an Internal node and not at max_depth.
-                if current_depth < max_depth && next_log_token_opt.is_some() && !specific_token_path_followed && !wildcard_path_followed {
+                if current_depth < max_depth
+                    && next_log_token_opt.is_some()
+                    && !specific_token_path_followed
+                    && !wildcard_path_followed
+                {
                     // No direct path continuation for the current log sequence. Collect all children.
                     for (token, child_node) in children_map.iter() {
                         let mut path_to_child = current_path.clone();
                         path_to_child.push(*token);
                         // Call the free function
-                        collect_all_groups_in_subtree_free(child_node, path_to_child, candidate_paths);
+                        collect_all_groups_in_subtree_free(
+                            child_node,
+                            path_to_child,
+                            candidate_paths,
+                        );
                     }
                 }
             }
@@ -286,11 +292,8 @@ impl TwoStageDrain {
             }
         }
     }
-    
-    fn collect_log_groups_from_node(
-        node: &mut Node,
-        all_log_groups: &mut Vec<LogGroup>,
-    ) {
+
+    fn collect_log_groups_from_node(node: &mut Node, all_log_groups: &mut Vec<LogGroup>) {
         match node.kind {
             NodeKind::Leaf(ref mut groups) => {
                 // This method is used when restructuring the tree (e.g. internal to leaf).
@@ -320,7 +323,7 @@ impl TwoStageDrain {
             }
         }
     }
-    
+
     // get_or_create_log_group_mut no longer needs &mut self
     // It operates on current_node and global INTERNER, and parameters.
     // However, to be callable from process_line which has &mut self,
@@ -356,7 +359,6 @@ impl TwoStageDrain {
         max_depth: usize,
         max_children: usize,
     ) -> &'a mut Vec<LogGroup> {
-
         // Case 1: Path is exhausted. Node must be a Leaf.
         if current_depth == record_tokens.len() {
             if !matches!(&current_node.kind, NodeKind::Leaf(_)) {
@@ -373,19 +375,20 @@ impl TwoStageDrain {
 
         // Case 2: Max depth reached. Node must become a Leaf.
         if current_depth + 1 >= max_depth {
-            let final_groups_for_leaf = match std::mem::replace(&mut current_node.kind, NodeKind::Leaf(Vec::new())) {
-                NodeKind::Internal(mut children_map_taken) => {
-                    let mut collected_groups = Vec::new();
-                    for child_node in children_map_taken.values_mut() {
-                        Self::collect_log_groups_from_node(child_node, &mut collected_groups);
+            let final_groups_for_leaf =
+                match std::mem::replace(&mut current_node.kind, NodeKind::Leaf(Vec::new())) {
+                    NodeKind::Internal(mut children_map_taken) => {
+                        let mut collected_groups = Vec::new();
+                        for child_node in children_map_taken.values_mut() {
+                            Self::collect_log_groups_from_node(child_node, &mut collected_groups);
+                        }
+                        collected_groups
                     }
-                    collected_groups
-                }
-                NodeKind::Leaf(existing_groups) => existing_groups,
-                // No other kinds expected if Node is always constructed as Internal or Leaf.
-            };
+                    NodeKind::Leaf(existing_groups) => existing_groups,
+                    // No other kinds expected if Node is always constructed as Internal or Leaf.
+                };
             current_node.kind = NodeKind::Leaf(final_groups_for_leaf);
-            
+
             match &mut current_node.kind {
                 NodeKind::Leaf(log_groups) => return log_groups,
                 _ => unreachable!("Node converted to Leaf at max_depth."),
@@ -408,11 +411,14 @@ impl TwoStageDrain {
             match &mut current_node.kind {
                 NodeKind::Internal(children_map) => {
                     let token_for_this_depth = record_tokens[current_depth];
-                    if children_map.len() >= max_children && !children_map.contains_key(&token_for_this_depth) {
+                    if children_map.len() >= max_children
+                        && !children_map.contains_key(&token_for_this_depth)
+                    {
                         // Condition: Internal node is full and current token is not a child. Convert to Leaf.
                         let mut taken_map = std::mem::take(children_map); // children_map is now empty.
                         let mut collected_groups = Vec::new();
-                        for (_symbol, node_in_map) in taken_map.iter_mut() { // Iterate over the owned map
+                        for (_symbol, node_in_map) in taken_map.iter_mut() {
+                            // Iterate over the owned map
                             Self::collect_log_groups_from_node(node_in_map, &mut collected_groups);
                         }
                         action = DeterminedAction::TransformToLeaf(collected_groups);
@@ -426,7 +432,10 @@ impl TwoStageDrain {
                     let taken_groups = std::mem::take(log_groups_vec); // log_groups_vec is now empty.
                     let mut new_children_map = HashMap::new();
                     if !taken_groups.is_empty() {
-                        new_children_map.insert(*DRAIN_ASTERISK, Node::new_leaf_node_with_groups(taken_groups));
+                        new_children_map.insert(
+                            *DRAIN_ASTERISK,
+                            Node::new_leaf_node_with_groups(taken_groups),
+                        );
                     }
                     action = DeterminedAction::TransformToInternal(new_children_map);
                 }
@@ -450,8 +459,16 @@ impl TwoStageDrain {
                     // This is a new, distinct borrow.
                     if let NodeKind::Internal(children_map) = &mut current_node.kind {
                         let token_for_this_depth = record_tokens[current_depth];
-                        let child_node = children_map.entry(token_for_this_depth).or_insert_with(Node::new_internal_node);
-                        return Self::get_or_create_log_group_mut(child_node, record_tokens, current_depth + 1, max_depth, max_children);
+                        let child_node = children_map
+                            .entry(token_for_this_depth)
+                            .or_insert_with(Node::new_internal_node);
+                        return Self::get_or_create_log_group_mut(
+                            child_node,
+                            record_tokens,
+                            current_depth + 1,
+                            max_depth,
+                            max_children,
+                        );
                     } else {
                         // This state should ideally not be reached if 'Recurse' was determined when it was Internal.
                         // Implies current_node.kind changed unexpectedly or logic error.
@@ -473,8 +490,12 @@ impl TwoStageDrain {
             .map(|s| Regex::new(s))
             .collect::<Result<Vec<Regex>, regex::Error>>()?;
 
-        let threshold_ratio = Ratio::from_float::<f32>(threshold)
-            .ok_or_else(|| anyhow!("Invalid threshold value: {} cannot be converted to a Ratio", threshold))?;
+        let threshold_ratio = Ratio::from_float::<f32>(threshold).ok_or_else(|| {
+            anyhow!(
+                "Invalid threshold value: {} cannot be converted to a Ratio",
+                threshold
+            )
+        })?;
 
         Ok(Self {
             domain: domain_patterns,
@@ -488,8 +509,8 @@ impl TwoStageDrain {
     }
 
     pub fn process_line(&mut self, line: String) -> Result<bool, Error> {
-        let local_max_depth = self.max_depth; 
-        let local_max_children = self.max_children; 
+        let local_max_depth = self.max_depth;
+        let local_max_children = self.max_children;
         let local_threshold = self.threshold.clone();
         let local_domain = self.domain.clone();
 
@@ -505,8 +526,8 @@ impl TwoStageDrain {
         if processed_line.is_empty() || processed_line == "<*>" {
             return Ok(false);
         }
-        
-        let new_record = Record::new(processed_line.clone()); 
+
+        let new_record = Record::new(processed_line.clone());
 
         let processed_line_tokens: Vec<DefaultSymbol> = {
             let mut interner = self.strings.write(); // Use self.strings (shared interner)
@@ -519,7 +540,7 @@ impl TwoStageDrain {
         if processed_line_tokens.is_empty() {
             return Ok(false);
         }
-        
+
         self.line_count_processed += 1;
         let length = processed_line_tokens.len();
 
@@ -538,11 +559,14 @@ impl TwoStageDrain {
                 &mut candidate_infos,
             );
 
-            for (path, group_id) in candidate_infos { // candidate_infos contains (path_to_leaf, log_group_id)
+            for (path, group_id) in candidate_infos {
+                // candidate_infos contains (path_to_leaf, log_group_id)
                 // find_log_group_in_node_by_id needs to search from the same root_node
                 if let Some(lg) = Self::find_log_group_in_node_by_id(root_node, group_id) {
                     let current_score = new_record.calc_sim_score(lg.event());
-                    if best_match_info.is_none() || current_score > best_match_info.as_ref().unwrap().2 {
+                    if best_match_info.is_none()
+                        || current_score > best_match_info.as_ref().unwrap().2
+                    {
                         best_match_info = Some((path, group_id, current_score));
                     }
                 }
@@ -550,7 +574,10 @@ impl TwoStageDrain {
         }
 
         // Mutable Phase: Update existing group or create a new one
-        let root_node_for_length_mut = self.tree.entry(length).or_insert_with(Node::new_internal_node);
+        let root_node_for_length_mut = self
+            .tree
+            .entry(length)
+            .or_insert_with(Node::new_internal_node);
 
         if let Some((best_path_to_leaf, best_group_id, best_score)) = best_match_info {
             let score_ratio = if length > 0 {
@@ -563,13 +590,16 @@ impl TwoStageDrain {
                 // Use best_path_to_leaf to get to the Vec<LogGroup>
                 let target_log_groups_vec = Self::get_or_create_log_group_mut(
                     root_node_for_length_mut,
-                    &best_path_to_leaf, 
+                    &best_path_to_leaf,
                     0, // Start depth from 0 for get_or_create_log_group_mut
                     local_max_depth,
                     local_max_children,
                 );
 
-                if let Some(found_group) = target_log_groups_vec.iter_mut().find(|g| g.id == best_group_id) {
+                if let Some(found_group) = target_log_groups_vec
+                    .iter_mut()
+                    .find(|g| g.id == best_group_id)
+                {
                     found_group.add_example(new_record.clone()); // Clone new_record for this case
                     return Ok(false); // Matched existing group
                 }
@@ -578,12 +608,12 @@ impl TwoStageDrain {
                 // Fall through to create a new group, though this indicates a potential issue.
             }
         }
-        
+
         // Create new group: No candidates, no root_node for length, or best match below threshold, or inconsistent state.
         let log_groups_vec_for_new = Self::get_or_create_log_group_mut(
             root_node_for_length_mut,
             &processed_line_tokens, // Path for the new group is simply its own tokens
-            0, // Start depth from 0
+            0,                      // Start depth from 0
             local_max_depth,
             local_max_children,
         );

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,3 +16,18 @@ extern crate enum_derive;
 pub mod drains;
 pub mod log_group;
 pub mod record;
+
+/// # Log Querying
+///
+/// This module provides structures and functions for querying processed log data that has
+/// been structured into `LogGroup`s. The primary structure for accessing and managing
+/// this data is the `LogStore`.
+///
+/// Key functionalities include:
+/// - Storing and retrieving `LogGroup`s by their unique ID.
+/// - Filtering `LogGroup`s based on a specific time range.
+/// - Performing range-based aggregation on the example records of a specific `LogGroup`
+///   (identified by its ID) via the `query::query_log_range_aggregation` function.
+///   This allows for detailed analysis of log events matching a particular pattern
+///   within a given time window.
+pub mod query;

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -128,11 +128,15 @@ impl LogGroup {
         // Ksuid::get_time returns DateTime<Utc>
         // For now, let's assume we want to keep the DateTime<Utc> type
         // This will require more significant changes if we need to extract time directly from Uuid
-        // For now, this will cause a compile error, which we will fix in a subsequent step.
-        // Placeholder to satisfy the type checker for now, will be addressed.
+        // Uuid::get_timestamp returns Option<Timestamp>
+        // Timestamp::to_unix returns (u64, u32) for UUIDv1
+        // DateTime::from_timestamp expects i64 for seconds.
         self.event.uid.get_timestamp().map_or(Utc::now(), |ts| {
-            let (secs, nanos) = ts.to_unix();
-            DateTime::from_timestamp(secs.try_into().unwrap(), nanos).unwrap_or(Utc::now())
+            let (secs_u64, nanos) = ts.to_unix();
+            // Convert u64 seconds to i64. This is safe as long as the timestamp is not
+            // extremely far in the future, which is a reasonable assumption for log events.
+            let secs_i64 = secs_u64 as i64;
+            DateTime::from_timestamp(secs_i64, nanos).unwrap_or_else(|| Utc::now())
         })
     }
 }

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,11 +8,11 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
-use std::collections::HashMap;
-use uuid::Uuid;
-use chrono::{DateTime, Utc};
 use crate::log_group::LogGroup;
-use crate::record::Record; // Added for function return type and usage
+use crate::record::Record;
+use chrono::{DateTime, Utc};
+use std::collections::HashMap;
+use uuid::Uuid; // Added for function return type and usage
 
 pub struct LogStore {
     log_groups: HashMap<Uuid, LogGroup>,
@@ -41,7 +41,11 @@ impl LogStore {
         self.log_groups.get(&id)
     }
 
-    pub fn get_log_groups_in_range(&self, start_time: DateTime<Utc>, end_time: DateTime<Utc>) -> Vec<&LogGroup> {
+    pub fn get_log_groups_in_range(
+        &self,
+        start_time: DateTime<Utc>,
+        end_time: DateTime<Utc>,
+    ) -> Vec<&LogGroup> {
         self.log_groups
             .values()
             .filter(|log_group| {
@@ -67,7 +71,7 @@ pub fn query_log_range_aggregation<'a>(
                     record.uid.get_timestamp().map_or(false, |ts| {
                         let (secs_u64, nanos) = ts.to_unix();
                         // This conversion is safe for typical timestamp ranges
-                        let secs_i64 = secs_u64 as i64; 
+                        let secs_i64 = secs_u64 as i64;
                         if let Some(timestamp) = DateTime::from_timestamp(secs_i64, nanos) {
                             timestamp >= start_time && timestamp <= end_time
                         } else {
@@ -84,11 +88,11 @@ pub fn query_log_range_aggregation<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use chrono::{Utc}; // Removed Duration from here
-    use uuid::{Uuid, Version};
+    use chrono::Duration as ChronoDuration;
+    use chrono::Utc; // Removed Duration from here
     use std::thread::sleep;
     use std::time::Duration as StdDuration; // Added for sleep
-    use chrono::Duration as ChronoDuration; // Added for chrono operations
+    use uuid::{Uuid, Version}; // Added for chrono operations
 
     // Helper to create a record and get its timestamp
     fn get_record_timestamp(record: &Record) -> Option<DateTime<Utc>> {
@@ -105,7 +109,10 @@ mod tests {
         assert_eq!(record.uid.get_version(), Some(Version::Mac)); // v1 UUID
 
         let timestamp = get_record_timestamp(&record);
-        assert!(timestamp.is_some(), "Timestamp should be extractable from record UID");
+        assert!(
+            timestamp.is_some(),
+            "Timestamp should be extractable from record UID"
+        );
     }
 
     #[test]
@@ -118,12 +125,21 @@ mod tests {
         let after_creation = Utc::now();
 
         let group_time = log_group.get_time();
-        
+
         // Looser check: group_time should be between when we started and finished creation.
         // More precise check might require controlling Uuid::new_v1 which is complex.
-        assert!(group_time > now && group_time < after_creation, "LogGroup time {:?} should be between {:?} and {:?}", group_time, now, after_creation);
+        assert!(
+            group_time > now && group_time < after_creation,
+            "LogGroup time {:?} should be between {:?} and {:?}",
+            group_time,
+            now,
+            after_creation
+        );
         // Also check it's reasonably close to now (e.g., within a few seconds)
-        assert!((Utc::now() - group_time).num_seconds() < 5, "LogGroup time should be recent");
+        assert!(
+            (Utc::now() - group_time).num_seconds() < 5,
+            "LogGroup time should be recent"
+        );
     }
 
     #[test]
@@ -136,11 +152,22 @@ mod tests {
         let group_id = log_group.id;
 
         store.add_log_group(log_group);
-        assert_eq!(store.log_groups.len(), 1, "LogStore should have one group after adding");
+        assert_eq!(
+            store.log_groups.len(),
+            1,
+            "LogStore should have one group after adding"
+        );
 
         let retrieved_group = store.get_log_group_by_id(group_id);
-        assert!(retrieved_group.is_some(), "Should retrieve the added log group");
-        assert_eq!(retrieved_group.unwrap().id, group_id, "Retrieved group ID should match");
+        assert!(
+            retrieved_group.is_some(),
+            "Should retrieve the added log group"
+        );
+        assert_eq!(
+            retrieved_group.unwrap().id,
+            group_id,
+            "Retrieved group ID should match"
+        );
     }
 
     #[test]
@@ -157,9 +184,19 @@ mod tests {
         let groups = vec![group1, group2]; // group1 and group2 are moved here
         let store = LogStore::from_log_groups(groups);
 
-        assert_eq!(store.log_groups.len(), 2, "LogStore should contain two groups");
-        assert!(store.get_log_group_by_id(id1).is_some(), "Group 1 should be in the store");
-        assert!(store.get_log_group_by_id(id2).is_some(), "Group 2 should be in the store");
+        assert_eq!(
+            store.log_groups.len(),
+            2,
+            "LogStore should contain two groups"
+        );
+        assert!(
+            store.get_log_group_by_id(id1).is_some(),
+            "Group 1 should be in the store"
+        );
+        assert!(
+            store.get_log_group_by_id(id2).is_some(),
+            "Group 2 should be in the store"
+        );
     }
 
     #[test]
@@ -176,7 +213,10 @@ mod tests {
 
         let non_existent_id = Uuid::new_v4(); // Different type of UUID, but fine for testing non-existence
         let not_found_group = store.get_log_group_by_id(non_existent_id);
-        assert!(not_found_group.is_none(), "Should return None for non-existent group ID");
+        assert!(
+            not_found_group.is_none(),
+            "Should return None for non-existent group ID"
+        );
     }
 
     #[test]
@@ -185,73 +225,118 @@ mod tests {
         let base_time = Utc::now();
 
         // Create groups with timestamps approximately 100ms apart
-        let r1 = Record::new("g1".to_string()); let g1 = LogGroup::new(r1); // ~base_time
+        let r1 = Record::new("g1".to_string());
+        let g1 = LogGroup::new(r1); // ~base_time
         let id1 = g1.id;
-        groups_to_add.push(g1); 
+        groups_to_add.push(g1);
         sleep(StdDuration::from_millis(100));
 
-        let r2 = Record::new("g2".to_string()); let g2 = LogGroup::new(r2); // ~base_time + 100ms
+        let r2 = Record::new("g2".to_string());
+        let g2 = LogGroup::new(r2); // ~base_time + 100ms
         let id2 = g2.id;
         groups_to_add.push(g2);
         sleep(StdDuration::from_millis(100));
 
-        let r3 = Record::new("g3".to_string()); let g3 = LogGroup::new(r3); // ~base_time + 200ms
+        let r3 = Record::new("g3".to_string());
+        let g3 = LogGroup::new(r3); // ~base_time + 200ms
         let id3 = g3.id;
         groups_to_add.push(g3);
-        
+
         let store = LogStore::from_log_groups(groups_to_add);
-        
+
         // Fetch the actual stored groups by their original IDs to get their correct timestamps
-        let stored_g1 = store.get_log_group_by_id(id1).expect("g1 not found in store");
+        let stored_g1 = store
+            .get_log_group_by_id(id1)
+            .expect("g1 not found in store");
         let time1 = stored_g1.get_time();
-        let stored_g2 = store.get_log_group_by_id(id2).expect("g2 not found in store");
+        let stored_g2 = store
+            .get_log_group_by_id(id2)
+            .expect("g2 not found in store");
         let time2 = stored_g2.get_time();
-        let stored_g3 = store.get_log_group_by_id(id3).expect("g3 not found in store");
+        let stored_g3 = store
+            .get_log_group_by_id(id3)
+            .expect("g3 not found in store");
         let time3 = stored_g3.get_time();
 
         // Ensure times are ordered as expected due to sleep, with some tolerance
         assert!(time1 < time2, "time1 should be less than time2");
         assert!(time2 < time3, "time2 should be less than time3");
 
-
         // Scenario 1: Range includes all
         let all_groups = store.get_log_groups_in_range(time1, time3);
-        assert_eq!(all_groups.len(), 3, "Should find all 3 groups. Found: {:?}", all_groups.iter().map(|g| g.id).collect::<Vec<_>>());
-
+        assert_eq!(
+            all_groups.len(),
+            3,
+            "Should find all 3 groups. Found: {:?}",
+            all_groups.iter().map(|g| g.id).collect::<Vec<_>>()
+        );
 
         // Scenario 2: Range includes some (middle one)
-        let some_groups_middle = store.get_log_groups_in_range(time1 + ChronoDuration::milliseconds(50), time3 - ChronoDuration::milliseconds(50));
+        let some_groups_middle = store.get_log_groups_in_range(
+            time1 + ChronoDuration::milliseconds(50),
+            time3 - ChronoDuration::milliseconds(50),
+        );
         assert_eq!(some_groups_middle.len(), 1, "Should find 1 group (g2)");
         assert_eq!(some_groups_middle[0].id, stored_g2.id);
-        
+
         // Scenario 3: Range includes some (first two)
         let some_groups_first_two = store.get_log_groups_in_range(time1, time2);
-        assert_eq!(some_groups_first_two.len(), 2, "Should find 2 groups (g1, g2)");
+        assert_eq!(
+            some_groups_first_two.len(),
+            2,
+            "Should find 2 groups (g1, g2)"
+        );
 
         // Scenario 4: Range includes none (before all)
-        let no_groups_before = store.get_log_groups_in_range(base_time - ChronoDuration::seconds(10), base_time - ChronoDuration::seconds(5));
-        assert_eq!(no_groups_before.len(), 0, "Should find no groups (range before all)");
+        let no_groups_before = store.get_log_groups_in_range(
+            base_time - ChronoDuration::seconds(10),
+            base_time - ChronoDuration::seconds(5),
+        );
+        assert_eq!(
+            no_groups_before.len(),
+            0,
+            "Should find no groups (range before all)"
+        );
 
         // Scenario 5: Range includes none (after all)
-        let no_groups_after = store.get_log_groups_in_range(time3 + ChronoDuration::seconds(5), time3 + ChronoDuration::seconds(10));
-        assert_eq!(no_groups_after.len(), 0, "Should find no groups (range after all)");
+        let no_groups_after = store.get_log_groups_in_range(
+            time3 + ChronoDuration::seconds(5),
+            time3 + ChronoDuration::seconds(10),
+        );
+        assert_eq!(
+            no_groups_after.len(),
+            0,
+            "Should find no groups (range after all)"
+        );
 
         // Scenario 6: Range is start_time == end_time (exact match for g2)
         let exact_match_g2 = store.get_log_groups_in_range(time2, time2);
-        assert_eq!(exact_match_g2.len(), 1, "Should find g2 with exact time match");
+        assert_eq!(
+            exact_match_g2.len(),
+            1,
+            "Should find g2 with exact time match"
+        );
         assert_eq!(exact_match_g2[0].id, stored_g2.id);
-        
+
         // Scenario 7: Edge case - g1 exactly on start_time
         let edge_start = store.get_log_groups_in_range(time1, time1);
-        assert_eq!(edge_start.len(), 1, "Should find g1 when it's exactly on start_time");
+        assert_eq!(
+            edge_start.len(),
+            1,
+            "Should find g1 when it's exactly on start_time"
+        );
         assert_eq!(edge_start[0].id, stored_g1.id);
 
         // Scenario 8: Edge case - g3 exactly on end_time
         let edge_end = store.get_log_groups_in_range(time3, time3);
-         assert_eq!(edge_end.len(), 1, "Should find g3 when it's exactly on end_time");
+        assert_eq!(
+            edge_end.len(),
+            1,
+            "Should find g3 when it's exactly on end_time"
+        );
         assert_eq!(edge_end[0].id, stored_g3.id);
     }
-    
+
     #[test]
     fn test_query_log_range_aggregation() {
         let mut store = LogStore::new();
@@ -270,43 +355,78 @@ mod tests {
         let time2 = get_record_timestamp(&ex_r2).unwrap();
         log_group.add_example(ex_r2);
         sleep(StdDuration::from_millis(50));
-        
+
         let ex_r3 = Record::new("Example 3".to_string()); // ~base_time + 100ms
         let time3 = get_record_timestamp(&ex_r3).unwrap();
         log_group.add_example(ex_r3);
 
         store.add_log_group(log_group);
-        
+
         // Scenario 1: Group ID not found
         let non_existent_id = Uuid::new_v4();
-        let results_not_found = query_log_range_aggregation(&store, non_existent_id, base_time, Utc::now());
-        assert!(results_not_found.is_empty(), "Should return empty for non-existent group ID");
+        let results_not_found =
+            query_log_range_aggregation(&store, non_existent_id, base_time, Utc::now());
+        assert!(
+            results_not_found.is_empty(),
+            "Should return empty for non-existent group ID"
+        );
 
         // Scenario 2: Group ID found, but no records in the time range
-        let results_none_in_range = query_log_range_aggregation(&store, group_id, base_time - ChronoDuration::seconds(10), base_time - ChronoDuration::seconds(5));
-        assert!(results_none_in_range.is_empty(), "Should return empty if no records in time range");
+        let results_none_in_range = query_log_range_aggregation(
+            &store,
+            group_id,
+            base_time - ChronoDuration::seconds(10),
+            base_time - ChronoDuration::seconds(5),
+        );
+        assert!(
+            results_none_in_range.is_empty(),
+            "Should return empty if no records in time range"
+        );
 
         // Scenario 3: Group ID found, some records in the time range (middle one)
-        let results_some_in_range = query_log_range_aggregation(&store, group_id, time1 + ChronoDuration::milliseconds(25) , time3 - ChronoDuration::milliseconds(25));
-        assert_eq!(results_some_in_range.len(), 1, "Should find 1 record in the middle of the range");
-        assert_eq!(get_record_timestamp(results_some_in_range[0]).unwrap(), time2);
-
+        let results_some_in_range = query_log_range_aggregation(
+            &store,
+            group_id,
+            time1 + ChronoDuration::milliseconds(25),
+            time3 - ChronoDuration::milliseconds(25),
+        );
+        assert_eq!(
+            results_some_in_range.len(),
+            1,
+            "Should find 1 record in the middle of the range"
+        );
+        assert_eq!(
+            get_record_timestamp(results_some_in_range[0]).unwrap(),
+            time2
+        );
 
         // Scenario 4: Group ID found, all records in the time range
         let results_all_in_range = query_log_range_aggregation(&store, group_id, time1, time3);
-        assert_eq!(results_all_in_range.len(), 3, "Should find all 3 records in the range");
+        assert_eq!(
+            results_all_in_range.len(),
+            3,
+            "Should find all 3 records in the range"
+        );
 
         // Scenario 5: Edge cases for time ranges
         // Record 1 exactly on start_time
         let results_edge_start = query_log_range_aggregation(&store, group_id, time1, time1);
-        assert_eq!(results_edge_start.len(), 1, "Should find record 1 when it is exactly on start_time");
+        assert_eq!(
+            results_edge_start.len(),
+            1,
+            "Should find record 1 when it is exactly on start_time"
+        );
         assert_eq!(get_record_timestamp(results_edge_start[0]).unwrap(), time1);
 
         // Record 3 exactly on end_time
         let results_edge_end = query_log_range_aggregation(&store, group_id, time3, time3);
-        assert_eq!(results_edge_end.len(), 1, "Should find record 3 when it is exactly on end_time");
+        assert_eq!(
+            results_edge_end.len(),
+            1,
+            "Should find record 3 when it is exactly on end_time"
+        );
         assert_eq!(get_record_timestamp(results_edge_end[0]).unwrap(), time3);
-        
+
         // Range that includes first two
         let results_first_two = query_log_range_aggregation(&store, group_id, time1, time2);
         assert_eq!(results_first_two.len(), 2, "Should find first two records");

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,0 +1,314 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
+use std::collections::HashMap;
+use uuid::Uuid;
+use chrono::{DateTime, Utc};
+use crate::log_group::LogGroup;
+use crate::record::Record; // Added for function return type and usage
+
+pub struct LogStore {
+    log_groups: HashMap<Uuid, LogGroup>,
+}
+
+impl LogStore {
+    pub fn new() -> Self {
+        Self {
+            log_groups: HashMap::new(),
+        }
+    }
+
+    pub fn add_log_group(&mut self, log_group: LogGroup) {
+        self.log_groups.insert(log_group.id, log_group);
+    }
+
+    pub fn from_log_groups(groups: impl IntoIterator<Item = LogGroup>) -> Self {
+        let mut store = Self::new();
+        for group in groups {
+            store.add_log_group(group);
+        }
+        store
+    }
+
+    pub fn get_log_group_by_id(&self, id: Uuid) -> Option<&LogGroup> {
+        self.log_groups.get(&id)
+    }
+
+    pub fn get_log_groups_in_range(&self, start_time: DateTime<Utc>, end_time: DateTime<Utc>) -> Vec<&LogGroup> {
+        self.log_groups
+            .values()
+            .filter(|log_group| {
+                let timestamp = log_group.get_time();
+                timestamp >= start_time && timestamp <= end_time
+            })
+            .collect()
+    }
+}
+
+pub fn query_log_range_aggregation<'a>(
+    log_store: &'a LogStore,
+    group_id: Uuid,
+    start_time: DateTime<Utc>,
+    end_time: DateTime<Utc>,
+) -> Vec<&'a Record> {
+    match log_store.get_log_group_by_id(group_id) {
+        Some(log_group) => {
+            log_group
+                .get_examples()
+                .into_iter()
+                .filter(|record| {
+                    record.uid.get_timestamp().map_or(false, |ts| {
+                        let (secs_u64, nanos) = ts.to_unix();
+                        // This conversion is safe for typical timestamp ranges
+                        let secs_i64 = secs_u64 as i64; 
+                        if let Some(timestamp) = DateTime::from_timestamp(secs_i64, nanos) {
+                            timestamp >= start_time && timestamp <= end_time
+                        } else {
+                            false // Timestamp conversion failed
+                        }
+                    })
+                })
+                .collect()
+        }
+        None => vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Utc}; // Removed Duration from here
+    use uuid::{Uuid, Version};
+    use std::thread::sleep;
+    use std::time::Duration as StdDuration; // Added for sleep
+    use chrono::Duration as ChronoDuration; // Added for chrono operations
+
+    // Helper to create a record and get its timestamp
+    fn get_record_timestamp(record: &Record) -> Option<DateTime<Utc>> {
+        record.uid.get_timestamp().and_then(|ts| {
+            let (secs_u64, nanos) = ts.to_unix();
+            let secs_i64 = secs_u64 as i64;
+            DateTime::from_timestamp(secs_i64, nanos)
+        })
+    }
+
+    #[test]
+    fn test_record_uuid_timestamp_extraction() {
+        let record = Record::new("Test record for UUID and timestamp".to_string());
+        assert_eq!(record.uid.get_version(), Some(Version::Mac)); // v1 UUID
+
+        let timestamp = get_record_timestamp(&record);
+        assert!(timestamp.is_some(), "Timestamp should be extractable from record UID");
+    }
+
+    #[test]
+    fn test_log_group_timestamp_extraction() {
+        let now = Utc::now();
+        sleep(StdDuration::from_millis(10)); // Ensure time moves forward a bit
+        let record = Record::new("Test record for LogGroup timestamp".to_string());
+        let log_group = LogGroup::new(record);
+        sleep(StdDuration::from_millis(10)); // Ensure time moves forward a bit
+        let after_creation = Utc::now();
+
+        let group_time = log_group.get_time();
+        
+        // Looser check: group_time should be between when we started and finished creation.
+        // More precise check might require controlling Uuid::new_v1 which is complex.
+        assert!(group_time > now && group_time < after_creation, "LogGroup time {:?} should be between {:?} and {:?}", group_time, now, after_creation);
+        // Also check it's reasonably close to now (e.g., within a few seconds)
+        assert!((Utc::now() - group_time).num_seconds() < 5, "LogGroup time should be recent");
+    }
+
+    #[test]
+    fn test_log_store_new_and_add() {
+        let mut store = LogStore::new();
+        assert_eq!(store.log_groups.len(), 0, "New LogStore should be empty");
+
+        let record = Record::new("Test record for new_and_add".to_string());
+        let log_group = LogGroup::new(record);
+        let group_id = log_group.id;
+
+        store.add_log_group(log_group);
+        assert_eq!(store.log_groups.len(), 1, "LogStore should have one group after adding");
+
+        let retrieved_group = store.get_log_group_by_id(group_id);
+        assert!(retrieved_group.is_some(), "Should retrieve the added log group");
+        assert_eq!(retrieved_group.unwrap().id, group_id, "Retrieved group ID should match");
+    }
+
+    #[test]
+    fn test_log_store_from_log_groups() {
+        let record1 = Record::new("Record 1 for from_log_groups".to_string());
+        let group1 = LogGroup::new(record1);
+        let id1 = group1.id;
+
+        sleep(StdDuration::from_millis(10));
+        let record2 = Record::new("Record 2 for from_log_groups".to_string());
+        let group2 = LogGroup::new(record2);
+        let id2 = group2.id;
+
+        let groups = vec![group1, group2]; // group1 and group2 are moved here
+        let store = LogStore::from_log_groups(groups);
+
+        assert_eq!(store.log_groups.len(), 2, "LogStore should contain two groups");
+        assert!(store.get_log_group_by_id(id1).is_some(), "Group 1 should be in the store");
+        assert!(store.get_log_group_by_id(id2).is_some(), "Group 2 should be in the store");
+    }
+
+    #[test]
+    fn test_log_store_get_by_id() {
+        let record1 = Record::new("Record 1 for get_by_id".to_string());
+        let group1 = LogGroup::new(record1);
+        let id1 = group1.id;
+
+        let store = LogStore::from_log_groups(vec![group1]);
+
+        let found_group = store.get_log_group_by_id(id1);
+        assert!(found_group.is_some(), "Should find existing group by ID");
+        assert_eq!(found_group.unwrap().id, id1);
+
+        let non_existent_id = Uuid::new_v4(); // Different type of UUID, but fine for testing non-existence
+        let not_found_group = store.get_log_group_by_id(non_existent_id);
+        assert!(not_found_group.is_none(), "Should return None for non-existent group ID");
+    }
+
+    #[test]
+    fn test_log_store_get_in_range() {
+        let mut groups_to_add = Vec::new();
+        let base_time = Utc::now();
+
+        // Create groups with timestamps approximately 100ms apart
+        let r1 = Record::new("g1".to_string()); let g1 = LogGroup::new(r1); // ~base_time
+        let id1 = g1.id;
+        groups_to_add.push(g1); 
+        sleep(StdDuration::from_millis(100));
+
+        let r2 = Record::new("g2".to_string()); let g2 = LogGroup::new(r2); // ~base_time + 100ms
+        let id2 = g2.id;
+        groups_to_add.push(g2);
+        sleep(StdDuration::from_millis(100));
+
+        let r3 = Record::new("g3".to_string()); let g3 = LogGroup::new(r3); // ~base_time + 200ms
+        let id3 = g3.id;
+        groups_to_add.push(g3);
+        
+        let store = LogStore::from_log_groups(groups_to_add);
+        
+        // Fetch the actual stored groups by their original IDs to get their correct timestamps
+        let stored_g1 = store.get_log_group_by_id(id1).expect("g1 not found in store");
+        let time1 = stored_g1.get_time();
+        let stored_g2 = store.get_log_group_by_id(id2).expect("g2 not found in store");
+        let time2 = stored_g2.get_time();
+        let stored_g3 = store.get_log_group_by_id(id3).expect("g3 not found in store");
+        let time3 = stored_g3.get_time();
+
+        // Ensure times are ordered as expected due to sleep, with some tolerance
+        assert!(time1 < time2, "time1 should be less than time2");
+        assert!(time2 < time3, "time2 should be less than time3");
+
+
+        // Scenario 1: Range includes all
+        let all_groups = store.get_log_groups_in_range(time1, time3);
+        assert_eq!(all_groups.len(), 3, "Should find all 3 groups. Found: {:?}", all_groups.iter().map(|g| g.id).collect::<Vec<_>>());
+
+
+        // Scenario 2: Range includes some (middle one)
+        let some_groups_middle = store.get_log_groups_in_range(time1 + ChronoDuration::milliseconds(50), time3 - ChronoDuration::milliseconds(50));
+        assert_eq!(some_groups_middle.len(), 1, "Should find 1 group (g2)");
+        assert_eq!(some_groups_middle[0].id, stored_g2.id);
+        
+        // Scenario 3: Range includes some (first two)
+        let some_groups_first_two = store.get_log_groups_in_range(time1, time2);
+        assert_eq!(some_groups_first_two.len(), 2, "Should find 2 groups (g1, g2)");
+
+        // Scenario 4: Range includes none (before all)
+        let no_groups_before = store.get_log_groups_in_range(base_time - ChronoDuration::seconds(10), base_time - ChronoDuration::seconds(5));
+        assert_eq!(no_groups_before.len(), 0, "Should find no groups (range before all)");
+
+        // Scenario 5: Range includes none (after all)
+        let no_groups_after = store.get_log_groups_in_range(time3 + ChronoDuration::seconds(5), time3 + ChronoDuration::seconds(10));
+        assert_eq!(no_groups_after.len(), 0, "Should find no groups (range after all)");
+
+        // Scenario 6: Range is start_time == end_time (exact match for g2)
+        let exact_match_g2 = store.get_log_groups_in_range(time2, time2);
+        assert_eq!(exact_match_g2.len(), 1, "Should find g2 with exact time match");
+        assert_eq!(exact_match_g2[0].id, stored_g2.id);
+        
+        // Scenario 7: Edge case - g1 exactly on start_time
+        let edge_start = store.get_log_groups_in_range(time1, time1);
+        assert_eq!(edge_start.len(), 1, "Should find g1 when it's exactly on start_time");
+        assert_eq!(edge_start[0].id, stored_g1.id);
+
+        // Scenario 8: Edge case - g3 exactly on end_time
+        let edge_end = store.get_log_groups_in_range(time3, time3);
+         assert_eq!(edge_end.len(), 1, "Should find g3 when it's exactly on end_time");
+        assert_eq!(edge_end[0].id, stored_g3.id);
+    }
+    
+    #[test]
+    fn test_query_log_range_aggregation() {
+        let mut store = LogStore::new();
+        let record_template = Record::new("Log group for aggregation test".to_string());
+        let mut log_group = LogGroup::new(record_template);
+        let group_id = log_group.id;
+        let base_time = Utc::now();
+
+        // Create example records with varying timestamps
+        let ex_r1 = Record::new("Example 1".to_string()); // ~base_time
+        let time1 = get_record_timestamp(&ex_r1).unwrap();
+        log_group.add_example(ex_r1);
+        sleep(StdDuration::from_millis(50));
+
+        let ex_r2 = Record::new("Example 2".to_string()); // ~base_time + 50ms
+        let time2 = get_record_timestamp(&ex_r2).unwrap();
+        log_group.add_example(ex_r2);
+        sleep(StdDuration::from_millis(50));
+        
+        let ex_r3 = Record::new("Example 3".to_string()); // ~base_time + 100ms
+        let time3 = get_record_timestamp(&ex_r3).unwrap();
+        log_group.add_example(ex_r3);
+
+        store.add_log_group(log_group);
+        
+        // Scenario 1: Group ID not found
+        let non_existent_id = Uuid::new_v4();
+        let results_not_found = query_log_range_aggregation(&store, non_existent_id, base_time, Utc::now());
+        assert!(results_not_found.is_empty(), "Should return empty for non-existent group ID");
+
+        // Scenario 2: Group ID found, but no records in the time range
+        let results_none_in_range = query_log_range_aggregation(&store, group_id, base_time - ChronoDuration::seconds(10), base_time - ChronoDuration::seconds(5));
+        assert!(results_none_in_range.is_empty(), "Should return empty if no records in time range");
+
+        // Scenario 3: Group ID found, some records in the time range (middle one)
+        let results_some_in_range = query_log_range_aggregation(&store, group_id, time1 + ChronoDuration::milliseconds(25) , time3 - ChronoDuration::milliseconds(25));
+        assert_eq!(results_some_in_range.len(), 1, "Should find 1 record in the middle of the range");
+        assert_eq!(get_record_timestamp(results_some_in_range[0]).unwrap(), time2);
+
+
+        // Scenario 4: Group ID found, all records in the time range
+        let results_all_in_range = query_log_range_aggregation(&store, group_id, time1, time3);
+        assert_eq!(results_all_in_range.len(), 3, "Should find all 3 records in the range");
+
+        // Scenario 5: Edge cases for time ranges
+        // Record 1 exactly on start_time
+        let results_edge_start = query_log_range_aggregation(&store, group_id, time1, time1);
+        assert_eq!(results_edge_start.len(), 1, "Should find record 1 when it is exactly on start_time");
+        assert_eq!(get_record_timestamp(results_edge_start[0]).unwrap(), time1);
+
+        // Record 3 exactly on end_time
+        let results_edge_end = query_log_range_aggregation(&store, group_id, time3, time3);
+        assert_eq!(results_edge_end.len(), 1, "Should find record 3 when it is exactly on end_time");
+        assert_eq!(get_record_timestamp(results_edge_end[0]).unwrap(), time3);
+        
+        // Range that includes first two
+        let results_first_two = query_log_range_aggregation(&store, group_id, time1, time2);
+        assert_eq!(results_first_two.len(), 2, "Should find first two records");
+    }
+}

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -32,9 +32,22 @@ pub struct Record {
 impl Record {
     #[instrument(name = "Create new record", level = "trace", skip(line))]
     pub fn new(line: String) -> Self {
+        // Generate a V1 UUID (timestamp-based)
+        // Requires a timestamp and a 16-byte node ID.
+        // For the node ID, we can use a constant byte array.
+        // The uniqueness of the node ID is not critical for this application.
+        let now = chrono::Utc::now();
+        let context = uuid::NoContext; // Added context for clock sequence
+        let timestamp = uuid::v1::Timestamp::from_unix(
+            context, // Added context as the first argument
+            now.timestamp() as u64,
+            now.timestamp_subsec_nanos(),
+        );
+        // Example node ID, can be any 6 bytes.
+        const NODE_ID: &[u8; 6] = b"drainf";
         Self {
             inner: TokenStream::from_unicode_line(&line),
-            uid: Uuid::new_v4(),
+            uid: Uuid::new_v1(timestamp, NODE_ID),
         }
     }
 

--- a/src/record/mod.rs
+++ b/src/record/mod.rs
@@ -18,7 +18,7 @@ use string_interner::DefaultSymbol;
 use tracing::{debug, instrument};
 use uuid::Uuid;
 
-use self::tokens::{Token, TokenStream, Offset}; // Added Offset, removed TypedToken
+use self::tokens::{Offset, Token, TokenStream}; // Added Offset, removed TypedToken
 use crate::drains::simple::INTERNER;
 
 lazy_static! {
@@ -61,23 +61,34 @@ impl Record {
         // The iterator for `self` (template) should yield Tokens.
         // The iterator for `candidate` (new line) can yield resolved Strings or Tokens.
         // For simplicity, let's assume both yield Tokens for comparison.
-        self.inner.inner.iter() // Iterate over (Offset, Token) pairs in the template
+        self.inner
+            .inner
+            .iter() // Iterate over (Offset, Token) pairs in the template
             .zip(candidate.inner.inner.iter()) // Iterate over (Offset, Token) pairs in the candidate
             .filter(|((_, template_token), (_, candidate_token))| {
                 match template_token {
                     Token::Wildcard => {
-                        debug!("template token is Wildcard, matches candidate token {:?}", candidate_token);
+                        debug!(
+                            "template token is Wildcard, matches candidate token {:?}",
+                            candidate_token
+                        );
                         true // Wildcard in template matches any token in candidate
-                    },
+                    }
                     _ => {
                         // For non-wildcard tokens, they must be equal.
                         // This comparison depends on how PartialEq is implemented for Token.
                         // Assuming Token::Value(TypedToken::String(Symbol)) comparison works.
                         if template_token == candidate_token {
-                            debug!("template token {:?} matches candidate token {:?}", template_token, candidate_token);
+                            debug!(
+                                "template token {:?} matches candidate token {:?}",
+                                template_token, candidate_token
+                            );
                             true
                         } else {
-                            debug!("template token {:?} does NOT match candidate token {:?}", template_token, candidate_token);
+                            debug!(
+                                "template token {:?} does NOT match candidate token {:?}",
+                                template_token, candidate_token
+                            );
                             false
                         }
                     }
@@ -125,8 +136,12 @@ impl Iterator for IntoIter {
             return None;
         }
         // Use .to_string() which now correctly handles <*> for Token::Wildcard
-        let token_display = self.record.inner.get_token_at_index(self.index).map(|t| t.to_string());
-        
+        let token_display = self
+            .record
+            .inner
+            .get_token_at_index(self.index)
+            .map(|t| t.to_string());
+
         self.index += 1;
         token_display
     }
@@ -148,13 +163,13 @@ impl IntoIterator for Record {
 // It should yield actual Token variants.
 impl<'a> IntoIterator for &'a Record {
     type Item = &'a Token; // Yields references to Tokens
-    type IntoIter = std::iter::Map<std::slice::Iter<'a, (Offset, Token)>, fn(&(Offset, Token)) -> &Token>;
+    type IntoIter =
+        std::iter::Map<std::slice::Iter<'a, (Offset, Token)>, fn(&(Offset, Token)) -> &Token>;
 
     fn into_iter(self) -> Self::IntoIter {
         self.inner.inner.iter().map(|(_, token)| token)
     }
 }
-
 
 impl fmt::Display for Record {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {


### PR DESCRIPTION
This commit introduces Stage 1 of a LogQL-inspired interface, allowing for log range aggregation on specified record types (LogGroups) by their ID.

Key features implemented:
- Modified Record and LogGroup UUIDs to be time-ordered (v1) to support time-based queries.
- Introduced a `LogStore` struct to hold processed log data, designed to be drain-agnostic.
- Implemented `LogStore::get_log_group_by_id` and `LogStore::get_log_groups_in_range`.
- Added `query_log_range_aggregation` function to filter records from a specific LogGroup within a given time range.
- Included a comprehensive unit test suite for the new query functionality.

Additionally, this commit adds benchmark tests for the existing drain backends (`SingleLayer` and `TwoStageDrain`):
- Benchmarks cover `process_line` throughput for both drains.
- Benchmarks measure the time to populate a `LogStore` from both drains.
- Benchmarks assess query performance (`query_log_range_aggregation`) on data processed by each drain type.
- Added a `collect_all_log_groups` method to `TwoStageDrain` to facilitate benchmarking.
- Resolved compilation issues in the benchmark environment, particularly with random data generation.