### PR TITLE
I've made some changes to fix CI benchmark errors and warnings.

### DIFF
--- a/benches/drain_benchmarks.rs
+++ b/benches/drain_benchmarks.rs
@@ -33,21 +33,21 @@ fn generate_log_lines(count: usize, seed: u64) -> Vec<String> {
     for i in 0..count {
         let current_time = base_time + ChronoDuration::milliseconds(i as i64);
         // Add some random variation to status and message to create more diverse log groups
-        let status: usize = rng.gen_range(200..600);
-        let message_length: usize = rng.gen_range(5..20);
+        let status: usize = rng.random_range(200_usize..600_usize);
+        let message_length: usize = rng.random_range(5_usize..20_usize);
         const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ\
                                 abcdefghijklmnopqrstuvwxyz\
                                 0123456789";
         let message: String = (0..message_length)
             .map(|_| {
-                let idx = rng.gen_range(0..CHARSET.len());
+                let idx = rng.random_range(0_usize..CHARSET.len());
                 CHARSET[idx] as char
             })
             .collect();
 
         let template = RecordTemplate::Sendmail(Sendmail {
             ts: current_time.to_rfc3339(),
-            remote: format!("host{}.example.com", rng.gen_range(1..100)),
+            remote: format!("host{}.example.com", rng.random_range(1_usize..100_usize)),
             status,
             message,
         });
@@ -159,7 +159,7 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
                 b.iter(|| {
                     query_log_range_aggregation(
                         black_box(&store),
-                        black_box(target_group_id),
+                        black_box(drain_flow::query::QuerySource::ById(target_group_id)),
                         black_box(s),
                         black_box(e),
                     );
@@ -265,7 +265,7 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
                 b.iter(|| {
                     query_log_range_aggregation(
                         black_box(&store),
-                        black_box(target_group_id),
+                        black_box(drain_flow::query::QuerySource::ById(target_group_id)),
                         black_box(s),
                         black_box(e),
                     );

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -1,10 +1,14 @@
 use chrono::{Duration as ChronoDuration, Utc}; // DateTime removed
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 // Removed unresolved import: use log_ql_playground_project::{...};
-use drain_flow::{ // Assuming these are the correct replacements from the local crate
-    query::{execute_logql_query, query_log_range_aggregation, LineFilter, LogQlQuery, LogStore, QuerySource, StreamSelector},
-    record::Record,
+use drain_flow::{
     log_group::LogGroup,
+    // Assuming these are the correct replacements from the local crate
+    query::{
+        execute_logql_query, query_log_range_aggregation, LineFilter, LogQlQuery, LogStore,
+        QuerySource, StreamSelector,
+    },
+    record::Record,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -1,19 +1,21 @@
-use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use chrono::{Duration as ChronoDuration, Utc}; // DateTime removed
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use log_ql_playground_project::{
-    execute_logql_query, query_log_range_aggregation, LineFilter, LogGroup, LogQlQuery, LogStore,
-    QuerySource, Record, StreamSelector,
+// Removed unresolved import: use log_ql_playground_project::{...};
+use drain_flow::{ // Assuming these are the correct replacements from the local crate
+    query::{execute_logql_query, query_log_range_aggregation, LineFilter, LogQlQuery, LogStore, QuerySource, StreamSelector},
+    record::Record,
+    log_group::LogGroup,
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-use std::collections::VecDeque;
+// VecDeque removed: use std::collections::VecDeque;
 use uuid::Uuid; // Included as per prompt, though not used in this specific helper
 
 // Helper to create a LogStore with a specific number of groups and records
 fn setup_log_store(
     num_groups: usize,
     records_per_group: usize,
-    mut rng: &mut StdRng,
+    rng: &mut StdRng,
 ) -> (LogStore, Vec<Uuid>) {
     let mut log_groups = Vec::new();
     let mut group_ids = Vec::new();
@@ -21,7 +23,7 @@ fn setup_log_store(
         // Create a unique base record content for each group
         let base_record_content = format!(
             "Base record for group {} - {}",
-            Uuid::from_u128(rng.gen()),
+            Uuid::from_u128(rng.random()),
             i
         );
         let base_record = Record::new(base_record_content);
@@ -33,7 +35,7 @@ fn setup_log_store(
                 "Example record {} for group {} - {}",
                 j,
                 i,
-                Uuid::from_u128(rng.gen())
+                Uuid::from_u128(rng.random())
             );
             let record_str = if j % 2 == 0 {
                 format!("{} common_term_for_filtering", example_content)

--- a/benches/two_stage_drain_integration_test.rs
+++ b/benches/two_stage_drain_integration_test.rs
@@ -11,6 +11,7 @@
 use anyhow::Result;
 use drain_flow::drains::two_stage_drain::TwoStageDrain; // Adjust path if necessary
 
+#[allow(dead_code)] // Suppress warning, as this is used by a test
 fn básico_drain_test_harness(lines: Vec<String>, expected_groups: usize) -> Result<()> {
     let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10)?; // Using default values for now
 

--- a/src/drains/two_stage_drain.rs
+++ b/src/drains/two_stage_drain.rs
@@ -221,7 +221,7 @@ impl TwoStageDrain {
                 // but only if it's different from the specific token path (or if specific token is not a wildcard)
                 // This check avoids double-counting if record_tokens[current_depth] is already DRAIN_ASTERISK
                 let specific_token_is_wildcard =
-                    next_log_token_opt.map_or(false, |t| *t == *DRAIN_ASTERISK);
+                    next_log_token_opt.is_some_and(|t| *t == *DRAIN_ASTERISK);
                 if !specific_token_is_wildcard {
                     // only try wildcard if specific token wasn't already the wildcard
                     if let Some(wildcard_child_node) = children_map.get(&*DRAIN_ASTERISK) {
@@ -272,7 +272,7 @@ impl TwoStageDrain {
     }
 
     // Helper to find a log group by ID starting from a given node (immutable search)
-    fn find_log_group_in_node_by_id<'a>(node: &'a Node, group_id: Uuid) -> Option<&'a LogGroup> {
+    fn find_log_group_in_node_by_id(node: &Node, group_id: Uuid) -> Option<&LogGroup> {
         match &node.kind {
             NodeKind::Leaf(log_groups) => {
                 for lg in log_groups {

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -147,7 +147,7 @@ impl LogGroup {
             // Convert u64 seconds to i64. This is safe as long as the timestamp is not
             // extremely far in the future, which is a reasonable assumption for log events.
             let secs_i64 = secs_u64 as i64;
-            DateTime::from_timestamp(secs_i64, nanos).unwrap_or_else(|| Utc::now())
+            DateTime::from_timestamp(secs_i64, nanos).unwrap_or_else(Utc::now)
         })
     }
 }
@@ -157,7 +157,7 @@ impl fmt::Display for LogGroup {
         write!(
             f,
             "LogGroup ID: {}\nFirst Seen: {}\nEvent: {}\n{} examples and {} wildcards\n",
-            self.event.uid.to_string(), // Changed from serialize()
+            self.event.uid, // Changed from serialize()
             self.get_time(), // Changed from self.event.uid.get_time() to use the struct's method
             self.event,
             self.examples.len(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -249,16 +249,15 @@ mod tests {
             .prop_map(|(selector, filter)| LogQlQuery { selector, filter })
     }
 
-
     // Combined strategy for log groups and a query based on those groups
     fn arb_log_groups_and_query() -> impl Strategy<Value = (Vec<LogGroup>, LogQlQuery)> {
-        arb_log_store_data().prop_flat_map(|(groups, group_ids)| {
-            (Just(groups), arb_logql_query(group_ids))
-        })
+        arb_log_store_data()
+            .prop_flat_map(|(groups, group_ids)| (Just(groups), arb_logql_query(group_ids)))
     }
 
     // Combined strategy for log groups, query, and time range
-    fn arb_log_groups_query_and_times() -> impl Strategy<Value = (Vec<LogGroup>, LogQlQuery, DateTime<Utc>, DateTime<Utc>)> {
+    fn arb_log_groups_query_and_times(
+    ) -> impl Strategy<Value = (Vec<LogGroup>, LogQlQuery, DateTime<Utc>, DateTime<Utc>)> {
         arb_log_store_data().prop_flat_map(|(groups, group_ids)| {
             (
                 Just(groups),

--- a/src/query.rs
+++ b/src/query.rs
@@ -144,11 +144,10 @@ pub fn query_log_range_aggregation<'a>(
 mod tests {
     use super::*;
     use chrono::Duration as ChronoDuration;
-    use chrono::{TimeZone, Utc}; // Keep Utc, add TimeZone for later proptest use
+    use chrono::Utc; // Keep Utc, add TimeZone for later proptest use
     use proptest::collection::vec as prop_vec; // Added for proptest
     use proptest::prelude::*; // Added for proptest
     use proptest::sample::subsequence; // Added for subsequence
-    use rand::Rng;
     use std::collections::HashSet; // Added for proptest
     use std::thread::sleep;
     use std::time::Duration as StdDuration;

--- a/src/query.rs
+++ b/src/query.rs
@@ -19,6 +19,12 @@ pub struct LogStore {
     log_groups: HashMap<Uuid, LogGroup>,
 }
 
+impl Default for LogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl LogStore {
     pub fn new() -> Self {
         Self {
@@ -127,7 +133,7 @@ pub fn query_log_range_aggregation<'a>(
     initial_records
         .into_iter()
         .filter(|record| {
-            record.uid.get_timestamp().map_or(false, |ts| {
+            record.uid.get_timestamp().is_some_and(|ts| {
                 let (secs_u64, nanos) = ts.to_unix();
                 let secs_i64 = secs_u64 as i64;
                 if let Some(timestamp) = DateTime::from_timestamp(secs_i64, nanos) {


### PR DESCRIPTION
This commit addresses several issues identified in the CI logs and during local benchmark execution:

- Fixed compilation errors in `benches/drain_benchmarks.rs` by correctly wrapping `target_group_id` with `drain_flow::query::QuerySource::ById()`.
- Replaced deprecated `rand::Rng::gen_range` with `rand::Rng::random_range` in `benches/drain_benchmarks.rs` and `benches/query_benchmarks.rs`.
- Replaced deprecated `rand::Rng::gen` with `rand::Rng::random` in `benches/query_benchmarks.rs`.
- Removed unused imports in `src/query.rs` and `benches/query_benchmarks.rs`.
- Addressed a dead code warning for `básico_drain_test_harness` in `benches/two_stage_drain_integration_test.rs` by adding `#[allow(dead_code)]`, as the function is used by tests.
- Resolved an unresolved import in `benches/query_benchmarks.rs` by using items from the local `drain_flow` crate.
- Fixed an `unused_mut` warning in `benches/query_benchmarks.rs`.

Benchmarks should now run successfully with `cargo +nightly bench`.