### PR TITLE
Refactor Drains and LogQL to use a common Drain trait

### DIFF
--- a/benches/core_benchmarks.rs
+++ b/benches/core_benchmarks.rs
@@ -12,7 +12,11 @@ extern crate serde_derive;
 extern crate tinytemplate;
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use drain_flow::{drains::simple::SingleLayer, log_group::LogGroup, record::Record};
+use drain_flow::{
+    drains::{api::Drain, simple::SingleLayer}, // Added api::Drain
+    log_group::LogGroup,
+    record::Record,
+};
 
 // Really simplistic benchmark of adding new lines using a constant line
 // this is pretty unrealistic since after the first one the string interner
@@ -21,9 +25,11 @@ pub fn benchmark_new_lines(c: &mut Criterion) {
     let mut drain = SingleLayer::new(vec![]).unwrap();
     c.bench_function("new_lines", |b| {
         b.iter(|| {
-            drain.process_line(black_box(
-                "Sample line with a few words to score".to_string(),
-            ))
+            Drain::process_line(
+                &mut drain,
+                black_box("Sample line with a few words to score".to_string()),
+            )
+            .unwrap();
         })
     });
 }

--- a/benches/drain_benchmarks.rs
+++ b/benches/drain_benchmarks.rs
@@ -70,7 +70,8 @@ fn benchmark_single_layer_process_line(c: &mut Criterion) {
             let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
             b.iter(|| {
                 for line in &lines {
-                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap(); // Updated call
+                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap();
+                    // Updated call
                 }
             });
         });
@@ -78,7 +79,8 @@ fn benchmark_single_layer_process_line(c: &mut Criterion) {
     group.finish();
 }
 
-fn benchmark_single_layer_collect_groups_and_create_store(c: &mut Criterion) { // Renamed
+fn benchmark_single_layer_collect_groups_and_create_store(c: &mut Criterion) {
+    // Renamed
     let mut group = c.benchmark_group("SingleLayer_CollectAndStore"); // Updated group name
     let line_counts = [100, 1000, 5000];
     let seed = 42;
@@ -91,8 +93,7 @@ fn benchmark_single_layer_collect_groups_and_create_store(c: &mut Criterion) { /
             // but not part of the b.iter() loop, to focus on collection + store creation.
             // If drain population needs to be benchmarked *with* collection, it should be inside b.iter().
             // For now, assuming we benchmark collection and store creation on a pre-populated drain.
-            let mut drain =
-                SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+            let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
             for line in &lines {
                 Drain::process_line(&mut drain, line.clone()).unwrap();
             }
@@ -112,7 +113,8 @@ fn benchmark_single_layer_collect_groups_and_create_store(c: &mut Criterion) { /
 
                 let mut drain_for_iter =
                     SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
-                for line in &lines { // Populate drain inside iter
+                for line in &lines {
+                    // Populate drain inside iter
                     Drain::process_line(&mut drain_for_iter, line.clone()).unwrap();
                 }
 
@@ -141,7 +143,8 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
 
     // Find a group with examples for querying
     // get_log_groups_in_range now returns Vec<LogGroup> (owned)
-    let available_groups = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
+    let available_groups =
+        store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
     let target_group_id_opt = available_groups
         .iter() // Iterate over &LogGroup
         .find(|lg| !lg.get_examples().is_empty())
@@ -202,7 +205,8 @@ fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
                 TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
             b.iter(|| {
                 for line in &lines {
-                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap(); // Updated call
+                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap();
+                    // Updated call
                 }
             });
         });
@@ -210,7 +214,8 @@ fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
     group.finish();
 }
 
-fn benchmark_two_stage_drain_collect_groups_and_create_store(c: &mut Criterion) { // Renamed
+fn benchmark_two_stage_drain_collect_groups_and_create_store(c: &mut Criterion) {
+    // Renamed
     let mut group = c.benchmark_group("TwoStageDrain_CollectAndStore"); // Updated group name
     let line_counts = [100, 1000, 5000];
     let seed = 42;
@@ -223,11 +228,12 @@ fn benchmark_two_stage_drain_collect_groups_and_create_store(c: &mut Criterion) 
             b.iter(|| {
                 let mut drain_for_iter = TwoStageDrain::new(vec![], 0.5, 4, 100)
                     .expect("Failed to create TwoStageDrain");
-                for line in &lines { // Populate drain inside iter
+                for line in &lines {
+                    // Populate drain inside iter
                     Drain::process_line(&mut drain_for_iter, line.clone()).unwrap();
                 }
                 let _log_groups = drain_for_iter.collect_log_groups(); // Collect groups
-                let _store = LogStore::new(black_box(drain_for_iter));  // Create store
+                let _store = LogStore::new(black_box(drain_for_iter)); // Create store
             });
         });
     }
@@ -247,7 +253,8 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
     }
     let store = LogStore::new(drain); // drain is moved here
 
-    let available_groups = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
+    let available_groups =
+        store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
     let target_group_id_opt = available_groups
         .iter()
         .find(|lg| !lg.get_examples().is_empty())

--- a/benches/drain_benchmarks.rs
+++ b/benches/drain_benchmarks.rs
@@ -11,8 +11,8 @@
 use chrono::{Duration as ChronoDuration, Utc};
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use drain_flow::{
-    drains::{simple::SingleLayer, two_stage_drain::TwoStageDrain},
-    log_group::LogGroup,
+    drains::{api::Drain, simple::SingleLayer, two_stage_drain::TwoStageDrain}, // Added api::Drain
+    // log_group::LogGroup, // Removed as per compiler warning (unused)
     query::{query_log_range_aggregation, LogStore},
     // record::Record, // Removed as it's unused directly in this file
 };
@@ -70,7 +70,7 @@ fn benchmark_single_layer_process_line(c: &mut Criterion) {
             let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
             b.iter(|| {
                 for line in &lines {
-                    drain.process_line(black_box(line.clone())).unwrap();
+                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap(); // Updated call
                 }
             });
         });
@@ -78,8 +78,8 @@ fn benchmark_single_layer_process_line(c: &mut Criterion) {
     group.finish();
 }
 
-fn benchmark_log_store_from_single_layer(c: &mut Criterion) {
-    let mut group = c.benchmark_group("SingleLayer_LogStorePopulation");
+fn benchmark_single_layer_collect_groups_and_create_store(c: &mut Criterion) { // Renamed
+    let mut group = c.benchmark_group("SingleLayer_CollectAndStore"); // Updated group name
     let line_counts = [100, 1000, 5000];
     let seed = 42;
 
@@ -87,19 +87,37 @@ fn benchmark_log_store_from_single_layer(c: &mut Criterion) {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
             let lines = generate_log_lines(size, seed);
+            // Drain population is part of the setup for this specific benchmark iteration
+            // but not part of the b.iter() loop, to focus on collection + store creation.
+            // If drain population needs to be benchmarked *with* collection, it should be inside b.iter().
+            // For now, assuming we benchmark collection and store creation on a pre-populated drain.
+            let mut drain =
+                SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
+            for line in &lines {
+                Drain::process_line(&mut drain, line.clone()).unwrap();
+            }
+
             b.iter(|| {
-                let mut drain =
+                // In each iteration, collect groups and create the store.
+                // This means drain is cloned or re-populated if we want to measure population too.
+                // The current setup reuses the populated drain from outside b.iter,
+                // which means we are only measuring collect_log_groups and LogStore::new.
+                // To be consistent with "populating the drain as it does currently" *inside* the benchmarked loop:
+                // We need to decide if drain creation & population is part of what's measured for "LogStorePopulation"
+                // The original name `benchmark_log_store_from_single_layer` implied the whole process.
+                // Let's assume the intent is to benchmark the collection and store creation part primarily.
+                // So, the drain is populated once, then we benchmark collection + store creation.
+                // If drain state changes or is consumed by LogStore::new, then drain must be setup inside b.iter.
+                // Since LogStore::new(drain) takes ownership, drain needs to be setup inside.
+
+                let mut drain_for_iter =
                     SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
-                for line in &lines {
-                    drain.process_line(line.clone()).unwrap();
+                for line in &lines { // Populate drain inside iter
+                    Drain::process_line(&mut drain_for_iter, line.clone()).unwrap();
                 }
-                let log_groups_nested: Vec<Vec<&LogGroup>> = drain.iter_groups(); // Removed .collect()
-                let log_groups: Vec<LogGroup> = log_groups_nested
-                    .into_iter()
-                    .flatten()
-                    .map(|lg_ref| lg_ref.clone()) // Clone to get owned LogGroup
-                    .collect();
-                let _store = LogStore::from_log_groups(black_box(log_groups));
+
+                let _log_groups = drain_for_iter.collect_log_groups(); // Collect groups
+                let _store = LogStore::new(black_box(drain_for_iter)); // Create store
             });
         });
     }
@@ -114,20 +132,18 @@ fn benchmark_query_on_single_layer_data(c: &mut Criterion) {
 
     let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
     for line in &lines {
-        drain.process_line(line.clone()).unwrap();
+        Drain::process_line(&mut drain, line.clone()).unwrap();
     }
-    let log_groups_nested: Vec<Vec<&LogGroup>> = drain.iter_groups(); // Removed .collect()
-    let log_groups: Vec<LogGroup> = log_groups_nested
-        .into_iter()
-        .flatten()
-        .map(|lg_ref| lg_ref.clone())
-        .collect();
-    let store = LogStore::from_log_groups(log_groups);
+    // LogStore is now created with the drain instance.
+    // The drain is consumed by LogStore::new, so if drain is needed later, it must be cloned.
+    // For this benchmark, we populate the drain, then pass it to LogStore.
+    let store = LogStore::new(drain); // drain is moved here.
 
     // Find a group with examples for querying
-    let target_group_id_opt = store
-        .get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
-        .iter()
+    // get_log_groups_in_range now returns Vec<LogGroup> (owned)
+    let available_groups = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
+    let target_group_id_opt = available_groups
+        .iter() // Iterate over &LogGroup
         .find(|lg| !lg.get_examples().is_empty())
         .map(|lg| lg.id);
 
@@ -186,7 +202,7 @@ fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
                 TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
             b.iter(|| {
                 for line in &lines {
-                    drain.process_line(black_box(line.clone())).unwrap();
+                    Drain::process_line(&mut drain, black_box(line.clone())).unwrap(); // Updated call
                 }
             });
         });
@@ -194,8 +210,8 @@ fn benchmark_two_stage_drain_process_line(c: &mut Criterion) {
     group.finish();
 }
 
-fn benchmark_log_store_from_two_stage_drain(c: &mut Criterion) {
-    let mut group = c.benchmark_group("TwoStageDrain_LogStorePopulation");
+fn benchmark_two_stage_drain_collect_groups_and_create_store(c: &mut Criterion) { // Renamed
+    let mut group = c.benchmark_group("TwoStageDrain_CollectAndStore"); // Updated group name
     let line_counts = [100, 1000, 5000];
     let seed = 42;
 
@@ -203,14 +219,15 @@ fn benchmark_log_store_from_two_stage_drain(c: &mut Criterion) {
         group.throughput(Throughput::Elements(*count as u64));
         group.bench_with_input(BenchmarkId::from_parameter(count), count, |b, &size| {
             let lines = generate_log_lines(size, seed);
+            // Similar to SingleLayer, setting up drain inside b.iter for consistency
             b.iter(|| {
-                let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 100)
+                let mut drain_for_iter = TwoStageDrain::new(vec![], 0.5, 4, 100)
                     .expect("Failed to create TwoStageDrain");
-                for line in &lines {
-                    drain.process_line(line.clone()).unwrap();
+                for line in &lines { // Populate drain inside iter
+                    Drain::process_line(&mut drain_for_iter, line.clone()).unwrap();
                 }
-                let log_groups: Vec<LogGroup> = drain.collect_all_log_groups(); // Using the new method
-                let _store = LogStore::from_log_groups(black_box(log_groups));
+                let _log_groups = drain_for_iter.collect_log_groups(); // Collect groups
+                let _store = LogStore::new(black_box(drain_for_iter));  // Create store
             });
         });
     }
@@ -226,13 +243,12 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
     let mut drain =
         TwoStageDrain::new(vec![], 0.5, 4, 100).expect("Failed to create TwoStageDrain");
     for line in &lines {
-        drain.process_line(line.clone()).unwrap();
+        Drain::process_line(&mut drain, line.clone()).unwrap();
     }
-    let log_groups = drain.collect_all_log_groups();
-    let store = LogStore::from_log_groups(log_groups);
+    let store = LogStore::new(drain); // drain is moved here
 
-    let target_group_id_opt = store
-        .get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now())
+    let available_groups = store.get_log_groups_in_range(Utc::now() - ChronoDuration::days(365), Utc::now());
+    let target_group_id_opt = available_groups
         .iter()
         .find(|lg| !lg.get_examples().is_empty())
         .map(|lg| lg.id);
@@ -279,10 +295,10 @@ fn benchmark_query_on_two_stage_drain_data(c: &mut Criterion) {
 criterion_group!(
     benches,
     benchmark_single_layer_process_line,
-    benchmark_log_store_from_single_layer,
+    benchmark_single_layer_collect_groups_and_create_store, // Renamed
     benchmark_query_on_single_layer_data,
     benchmark_two_stage_drain_process_line,
-    benchmark_log_store_from_two_stage_drain,
+    benchmark_two_stage_drain_collect_groups_and_create_store, // Renamed
     benchmark_query_on_two_stage_drain_data
 );
 criterion_main!(benches);

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -1,61 +1,90 @@
-use chrono::{Duration as ChronoDuration, Utc}; // DateTime removed
+use chrono::{Duration as ChronoDuration, Utc};
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-// Removed unresolved import: use log_ql_playground_project::{...};
 use drain_flow::{
-    log_group::LogGroup,
-    // Assuming these are the correct replacements from the local crate
+    drains::{api::Drain, simple::SingleLayer}, // Added Drain and SingleLayer
+    // log_group::LogGroup, // Removed as unused
     query::{
         execute_logql_query, query_log_range_aggregation, LineFilter, LogQlQuery, LogStore,
         QuerySource, StreamSelector,
     },
-    record::Record,
+    // record::Record, // Removed as unused
 };
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
-// VecDeque removed: use std::collections::VecDeque;
-use uuid::Uuid; // Included as per prompt, though not used in this specific helper
+use uuid::Uuid;
 
 // Helper to create a LogStore with a specific number of groups and records
+// This function now populates a SingleLayer drain by processing lines.
 fn setup_log_store(
     num_groups: usize,
     records_per_group: usize,
     rng: &mut StdRng,
-) -> (LogStore, Vec<Uuid>) {
-    let mut log_groups = Vec::new();
-    let mut group_ids = Vec::new();
-    for i in 0..num_groups {
-        // Create a unique base record content for each group
-        let base_record_content = format!(
-            "Base record for group {} - {}",
-            Uuid::from_u128(rng.random()),
-            i
-        );
-        let base_record = Record::new(base_record_content);
-        let mut group = LogGroup::new(base_record);
-        group_ids.push(group.id);
+) -> (LogStore<SingleLayer>, Vec<Uuid>) {
+    let mut drain = SingleLayer::new(vec![]).expect("Failed to create SingleLayer drain");
 
+    for i in 0..num_groups {
+        // Create a unique base log line for each group
+        // Ensure this line is distinct enough to form its own group in SingleLayer if threshold is high enough,
+        // or similar enough if we want fewer groups. For simplicity, assume they form distinct groups.
+        let base_line = format!(
+            "Base log line for group {} {} {}",
+            i,
+            Uuid::from_u128(rng.random()), // Add UUID to ensure uniqueness for base
+            // Add some variable tokens that SingleLayer might use for grouping if not unique enough
+            (0..rng.random_range(3..7)) // Replaced gen_range
+                .map(|_| format!("token{}", rng.random_range(0..5))) // Replaced gen_range
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        Drain::process_line(&mut drain, base_line.clone())
+            .expect("Failed to process base line");
+
+        // Generate example lines for this group
         for j in 0..records_per_group {
-            let example_content = format!(
-                "Example record {} for group {} - {}",
-                j,
-                i,
-                Uuid::from_u128(rng.random())
-            );
-            let record_str = if j % 2 == 0 {
-                format!("{} common_term_for_filtering", example_content)
-            } else {
-                example_content
-            };
-            group.add_example(Record::new(record_str));
+            // A better example line generation that is similar to base_line for SingleLayer:
+            let mut base_tokens: Vec<&str> = base_line.split_whitespace().collect();
+            let tokens_to_change = rng.random_range(1..std::cmp::max(2, base_tokens.len() / 2)); // Replaced gen_range
+            for _ in 0..tokens_to_change {
+                if !base_tokens.is_empty() {
+                    let idx_to_change = rng.random_range(0..base_tokens.len()); // Replaced gen_range
+                    base_tokens[idx_to_change] = if j % 2 == 0 && idx_to_change == base_tokens.len() -1 { // Corrected index check
+                        "common_term_for_filtering"
+                    } else {
+                        // This needs a static string or a pool, can't use format! directly here easily
+                        // For simplicity, let's just append.
+                        "changed_token" // This was "changed_token"
+                    };
+                }
+            }
+            let mut modified_example_line = base_tokens.join(" ");
+            if j % 2 == 0 { // ensure common_term_for_filtering is present in some
+                if !modified_example_line.contains("common_term_for_filtering") { // Avoid duplicating if already changed
+                    modified_example_line.push_str(" common_term_for_filtering");
+                }
+            }
+            modified_example_line.push_str(&format!(" example_id_{}", Uuid::from_u128(rng.random())));
+
+
+            Drain::process_line(&mut drain, modified_example_line)
+                .expect("Failed to process example line");
         }
-        log_groups.push(group);
     }
-    (LogStore::from_log_groups(log_groups), group_ids)
+
+    let formed_log_groups = drain.collect_log_groups(); // This uses LogGroup from drain_flow::log_group
+    let group_ids: Vec<Uuid> = formed_log_groups.into_iter().map(|lg| lg.id).collect();
+
+    (LogStore::new(drain), group_ids)
 }
 
 fn benchmark_execute_logql_query(c: &mut Criterion) {
-    let mut rng = StdRng::seed_from_u64(42); // Fixed seed for deterministic results
+    let mut rng = StdRng::seed_from_u64(42);
     let (log_store, group_ids) = setup_log_store(10, 100, &mut rng);
+
+    // Ensure there are group_ids to select from, otherwise skip.
+    if group_ids.is_empty() {
+        println!("Warning: No log groups formed in setup_log_store for benchmark_execute_logql_query. Skipping.");
+        return;
+    }
 
     let query = LogQlQuery {
         selector: StreamSelector::LogGroupIds(group_ids.iter().take(5).cloned().collect()), // Select first 5 groups

--- a/benches/query_benchmarks.rs
+++ b/benches/query_benchmarks.rs
@@ -36,8 +36,7 @@ fn setup_log_store(
                 .collect::<Vec<_>>()
                 .join(" ")
         );
-        Drain::process_line(&mut drain, base_line.clone())
-            .expect("Failed to process base line");
+        Drain::process_line(&mut drain, base_line.clone()).expect("Failed to process base line");
 
         // Generate example lines for this group
         for j in 0..records_per_group {
@@ -47,23 +46,27 @@ fn setup_log_store(
             for _ in 0..tokens_to_change {
                 if !base_tokens.is_empty() {
                     let idx_to_change = rng.random_range(0..base_tokens.len()); // Replaced gen_range
-                    base_tokens[idx_to_change] = if j % 2 == 0 && idx_to_change == base_tokens.len() -1 { // Corrected index check
-                        "common_term_for_filtering"
-                    } else {
-                        // This needs a static string or a pool, can't use format! directly here easily
-                        // For simplicity, let's just append.
-                        "changed_token" // This was "changed_token"
-                    };
+                    base_tokens[idx_to_change] =
+                        if j % 2 == 0 && idx_to_change == base_tokens.len() - 1 {
+                            // Corrected index check
+                            "common_term_for_filtering"
+                        } else {
+                            // This needs a static string or a pool, can't use format! directly here easily
+                            // For simplicity, let's just append.
+                            "changed_token" // This was "changed_token"
+                        };
                 }
             }
             let mut modified_example_line = base_tokens.join(" ");
-            if j % 2 == 0 { // ensure common_term_for_filtering is present in some
-                if !modified_example_line.contains("common_term_for_filtering") { // Avoid duplicating if already changed
+            if j % 2 == 0 {
+                // ensure common_term_for_filtering is present in some
+                if !modified_example_line.contains("common_term_for_filtering") {
+                    // Avoid duplicating if already changed
                     modified_example_line.push_str(" common_term_for_filtering");
                 }
             }
-            modified_example_line.push_str(&format!(" example_id_{}", Uuid::from_u128(rng.random())));
-
+            modified_example_line
+                .push_str(&format!(" example_id_{}", Uuid::from_u128(rng.random())));
 
             Drain::process_line(&mut drain, modified_example_line)
                 .expect("Failed to process example line");
@@ -141,10 +144,9 @@ fn benchmark_qra_by_id(c: &mut Criterion) {
     let mut rng = StdRng::seed_from_u64(42);
     let (log_store, group_ids) = setup_log_store(10, 100, &mut rng);
 
-    let target_group_id = group_ids
+    let target_group_id = *group_ids
         .first()
-        .expect("Should have at least one group_id")
-        .clone();
+        .expect("Should have at least one group_id");
     let query_source = QuerySource::ById(target_group_id);
 
     let now = Utc::now();

--- a/benches/sink_benchmark.rs
+++ b/benches/sink_benchmark.rs
@@ -10,7 +10,7 @@
 
 use chrono::Utc;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use drain_flow::drains::simple::SingleLayer;
+use drain_flow::drains::{api::Drain, simple::SingleLayer}; // Added api::Drain
 use generators::{RecordTemplate, Sendmail};
 use rand::Rng;
 
@@ -46,7 +46,7 @@ pub fn benchmark_sink(c: &mut Criterion) {
             |b, lines| {
                 b.iter(|| {
                     for l in lines {
-                        drain.process_line(l.to_string()).unwrap();
+                        Drain::process_line(&mut drain, l.to_string()).unwrap(); // Updated call
                     }
                 });
             },

--- a/benches/sink_benchmark.rs
+++ b/benches/sink_benchmark.rs
@@ -46,7 +46,8 @@ pub fn benchmark_sink(c: &mut Criterion) {
             |b, lines| {
                 b.iter(|| {
                     for l in lines {
-                        Drain::process_line(&mut drain, l.to_string()).unwrap(); // Updated call
+                        Drain::process_line(&mut drain, l.to_string()).unwrap();
+                        // Updated call
                     }
                 });
             },

--- a/benches/two_stage_drain_integration_test.rs
+++ b/benches/two_stage_drain_integration_test.rs
@@ -9,28 +9,29 @@
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
 use anyhow::Result;
-use drain_flow::drains::two_stage_drain::TwoStageDrain; // Adjust path if necessary
+use drain_flow::drains::{api::Drain, two_stage_drain::TwoStageDrain}; // Adjust path if necessary, Added api::Drain
 
 #[allow(dead_code)] // Suppress warning, as this is used by a test
 fn básico_drain_test_harness(lines: Vec<String>, expected_groups: usize) -> Result<()> {
     let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10)?; // Using default values for now
 
     for line in lines {
-        drain.process_line(line)?;
+        Drain::process_line(&mut drain, line)?; // Updated call
     }
 
-    // We need a way to count the number of distinct log groups.
-    // The `iter_groups()` method in `SingleLayer` returns `Vec<Vec<&LogGroup>>`.
-    // We'll need a similar method in `TwoStageDrain` to count the groups for verification.
-    // For now, this test will expect `expected_groups` but won't be able to verify it
-    // until `iter_groups` or a similar method is implemented for `TwoStageDrain`.
-    // Add a TODO comment here.
-    // TODO: Implement a way to count log groups in TwoStageDrain and assert against expected_groups.
-    // For now, the test just ensures processing doesn't panic.
+    let groups = drain.collect_log_groups();
+    assert_eq!(
+        groups.len(),
+        expected_groups,
+        "Mismatch in expected number of log groups. Processed {} lines.",
+        drain.line_count_processed
+    );
+
     println!(
-        "Processed {} lines. Expected {} groups. (Verification pending iter_groups)",
-        drain.line_count_processed, expected_groups
-    ); // Placeholder for line_count
+        "Processed {} lines. Verified {} groups.",
+        drain.line_count_processed,
+        groups.len()
+    );
 
     Ok(())
 }
@@ -79,16 +80,26 @@ fn test_basic_drain_integration_with_preprocessing() -> Result<()> {
         "2023-10-27T10:04:00Z user-456 System shutdown initiated".to_string(),   // Match 2
         "2023-10-27T10:05:00Z user-123 System started successfully".to_string(), // Match 1
     ];
+    let line_count = lines.len(); // Store line count before moving lines
 
     for line in lines {
-        drain.process_line(line)?;
+        Drain::process_line(&mut drain, line)?; // Updated call
     }
 
     // Expected groups:
     // 1. "<*> <*> System started successfully"
     // 2. "<*> <*> System shutdown initiated"
-    // TODO: Implement group counting and verification for TwoStageDrain.
-    // For now, this test checks if processing completes without errors.
-    println!("Processed lines with preprocessing. (Verification of group count pending)");
+    let groups = drain.collect_log_groups();
+    assert_eq!(
+        groups.len(),
+        2, // Expected number of groups after preprocessing
+        "Mismatch in expected number of log groups after preprocessing. Processed {} lines.",
+        line_count // Use stored line_count
+    );
+    println!(
+        "Processed {} lines with preprocessing. Verified {} groups.",
+        line_count, // Use stored line_count
+        groups.len()
+    );
     Ok(())
 }

--- a/src/drains/api.rs
+++ b/src/drains/api.rs
@@ -8,8 +8,8 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
-use anyhow::Error;
 use crate::log_group::LogGroup;
+use anyhow::Error;
 
 /// Defines the core interface for log processing drains.
 ///

--- a/src/drains/api.rs
+++ b/src/drains/api.rs
@@ -1,0 +1,48 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
+use anyhow::Error;
+use crate::log_group::LogGroup;
+
+/// Defines the core interface for log processing drains.
+///
+/// The `Drain` trait abstracts the mechanism by which log lines are processed,
+/// clustered into `LogGroup`s, and subsequently retrieved. Implementations of
+/// this trait can offer various strategies for log analysis, such as simple
+/// in-memory storage or more complex, multi-stage processing pipelines.
+///
+/// This abstraction allows other parts of the system, like the `LogStore`,
+/// to operate on log data generically, without being coupled to a specific
+/// drain implementation.
+pub trait Drain {
+    /// Processes a single log line, potentially updating internal log group structures.
+    ///
+    /// # Parameters
+    ///
+    /// * `line`: A `String` representing the log line to be processed.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(true)`: If processing the line resulted in the creation of a new `LogGroup`.
+    /// * `Ok(false)`: If the line was successfully processed and added to an existing `LogGroup`.
+    /// * `Err(anyhow::Error)`: If an error occurred during processing.
+    fn process_line(&mut self, line: String) -> Result<bool, Error>;
+
+    /// Retrieves all unique `LogGroup`s currently managed by the drain.
+    ///
+    /// This method provides a snapshot of the log groups at the time of calling.
+    /// The order of log groups in the returned vector is not guaranteed.
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<LogGroup>` containing all log groups. If no log lines have been
+    /// processed or no groups have been formed, an empty vector is returned.
+    fn collect_log_groups(&self) -> Vec<LogGroup>;
+}

--- a/src/drains/mod.rs
+++ b/src/drains/mod.rs
@@ -1,3 +1,14 @@
+//! # Log Processing Drains
+//!
+//! This module provides mechanisms for processing, clustering, and managing log data.
+//! It includes the core `Drain` trait (defined in [`api::Drain`]), which establishes
+//! a common interface for various log processing strategies. Different implementations
+//! of this trait, such as [`simple::SingleLayer`] and [`two_stage_drain::TwoStageDrain`],
+//! offer distinct approaches to log analysis.
+//!
+//! The primary purpose of this module is to abstract the specifics of log processing,
+//! allowing other parts of the system to interact with log data through a consistent API.
+
 // Copyright Nicholas Harring. All rights reserved.
 //
 // This program is free software: you can redistribute it and/or modify it under
@@ -8,5 +19,6 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
+pub mod api;
 pub mod simple;
 pub mod two_stage_drain;

--- a/src/drains/simple.rs
+++ b/src/drains/simple.rs
@@ -146,11 +146,7 @@ impl Drain for SingleLayer {
     }
 
     fn collect_log_groups(&self) -> Vec<LogGroup> {
-        self.iter_groups()
-            .into_iter()
-            .flatten()
-            .cloned()
-            .collect()
+        self.iter_groups().into_iter().flatten().cloned().collect()
     }
 }
 

--- a/src/drains/simple.rs
+++ b/src/drains/simple.rs
@@ -19,7 +19,7 @@ use regex::Regex;
 use string_interner::{DefaultSymbol, StringInterner};
 use tracing::instrument;
 
-use crate::{log_group::LogGroup, record::Record};
+use crate::{drains::api::Drain, log_group::LogGroup, record::Record};
 
 lazy_static! {
     pub(crate) static ref INTERNER: Arc<RwLock<StringInterner<string_interner::backend::BucketBackend>>> =
@@ -62,6 +62,32 @@ impl SingleLayer {
         Ok(())
     }
 
+    #[instrument(skip(self), level = "trace")]
+    fn iter_groups(&self) -> Vec<Vec<&LogGroup>> {
+        let mut results: Vec<Vec<&LogGroup>> = Vec::new();
+        for length in self.base_layer.keys() {
+            let mut groups = vec![];
+            for (_, grp) in self.base_layer.get(length).unwrap().iter() {
+                for g in grp {
+                    groups.push(g);
+                }
+            }
+            results.push(groups);
+        }
+        results
+    }
+
+    #[instrument(skip(self), level = "trace")]
+    pub fn resolve(&self, sym: DefaultSymbol) -> String {
+        self.strings
+            .read()
+            .resolve(sym)
+            .expect("symbols must resolve")
+            .to_owned()
+    }
+}
+
+impl Drain for SingleLayer {
     /// Accepts a line of input for processing against existing records
     ///
     /// Return
@@ -69,7 +95,7 @@ impl SingleLayer {
     /// Ok(false) when the line matched an existing entry
     /// Err(e) for errors during processing
     #[instrument(skip(self, line))]
-    pub fn process_line(&mut self, line: String) -> Result<bool, Error> {
+    fn process_line(&mut self, line: String) -> Result<bool, Error> {
         if line.is_empty() {
             return Ok(false);
         }
@@ -119,28 +145,12 @@ impl SingleLayer {
         }
     }
 
-    #[instrument(skip(self), level = "trace")]
-    pub fn iter_groups(&self) -> Vec<Vec<&LogGroup>> {
-        let mut results: Vec<Vec<&LogGroup>> = Vec::new();
-        for length in self.base_layer.keys() {
-            let mut groups = vec![];
-            for (_, grp) in self.base_layer.get(length).unwrap().iter() {
-                for g in grp {
-                    groups.push(g);
-                }
-            }
-            results.push(groups);
-        }
-        results
-    }
-
-    #[instrument(skip(self), level = "trace")]
-    pub fn resolve(&self, sym: DefaultSymbol) -> String {
-        self.strings
-            .read()
-            .resolve(sym)
-            .expect("symbols must resolve")
-            .to_owned()
+    fn collect_log_groups(&self) -> Vec<LogGroup> {
+        self.iter_groups()
+            .into_iter()
+            .flatten()
+            .cloned()
+            .collect()
     }
 }
 
@@ -167,7 +177,7 @@ mod should {
     use spectral::prelude::*;
     use tracing_test::traced_test;
 
-    use crate::drains::simple::SingleLayer; // Removed <BucketBackend> for now, will add if compiler complains
+    use crate::drains::{api::Drain, simple::SingleLayer}; // Removed <BucketBackend> for now, will add if compiler complains
 
     #[traced_test]
     #[test]
@@ -215,10 +225,10 @@ mod should {
         let line_2 = "Another different order of words".to_string();
         let line_3 = "Finally one last unique set of character runs".to_string();
         let mut drain = SingleLayer::new(vec![]).unwrap();
-        drain.process_line(line_1).unwrap();
-        drain.process_line(line_2).unwrap();
-        drain.process_line(line_3).unwrap();
-        let groups = drain.iter_groups();
+        Drain::process_line(&mut drain, line_1).unwrap();
+        Drain::process_line(&mut drain, line_2).unwrap();
+        Drain::process_line(&mut drain, line_3).unwrap();
+        let groups = drain.collect_log_groups();
         assert_that(&groups).has_length(3);
     }
 }

--- a/src/drains/two_stage_drain.rs
+++ b/src/drains/two_stage_drain.rs
@@ -18,6 +18,7 @@ use regex::Regex;
 use string_interner::{DefaultSymbol, StringInterner};
 use uuid::Uuid;
 
+use crate::drains::api::Drain;
 use crate::log_group::LogGroup;
 use crate::record::Record;
 // Removed: use crate::record::tokens::ASTERISK;
@@ -89,14 +90,14 @@ mod tests {
     #[test]
     fn test_process_empty_line() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
-        assert_that(&drain.process_line("".to_string())).is_ok_containing(false);
+        assert_that(&Drain::process_line(&mut drain, "".to_string())).is_ok_containing(false);
     }
 
     #[traced_test]
     #[test]
     fn test_process_line_creates_new_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
-        assert_that(&drain.process_line("This is a test log line".to_string()))
+        assert_that(&Drain::process_line(&mut drain, "This is a test log line".to_string()))
             .is_ok_containing(true);
     }
 
@@ -104,8 +105,8 @@ mod tests {
     #[test]
     fn test_process_line_matches_existing_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 10, 10).unwrap(); // Increased max_depth for this test
-        let _ = drain.process_line("Log message type A value1".to_string());
-        assert_that(&drain.process_line("Log message type A value2".to_string()))
+        let _ = Drain::process_line(&mut drain, "Log message type A value1".to_string());
+        assert_that(&Drain::process_line(&mut drain, "Log message type A value2".to_string()))
             .is_ok_containing(false);
     }
 
@@ -113,8 +114,8 @@ mod tests {
     #[test]
     fn test_process_line_creates_second_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
-        let _ = drain.process_line("Log message type A value1".to_string());
-        assert_that(&drain.process_line("Completely different log message valueX".to_string()))
+        let _ = Drain::process_line(&mut drain, "Log message type A value1".to_string());
+        assert_that(&Drain::process_line(&mut drain, "Completely different log message valueX".to_string()))
             .is_ok_containing(true);
     }
 
@@ -126,11 +127,11 @@ mod tests {
 
         let line1 = "2023-10-26 This is a log".to_string();
         // First line should create a new group
-        assert_that(&drain.process_line(line1)).is_ok_containing(true);
+        assert_that(&Drain::process_line(&mut drain, line1)).is_ok_containing(true);
 
         // Second line, differing only in the preprocessed part, should match the existing group.
         let line2 = "2024-01-01 This is a log".to_string();
-        assert_that(&drain.process_line(line2)).is_ok_containing(false);
+        assert_that(&Drain::process_line(&mut drain, line2)).is_ok_containing(false);
     }
 }
 
@@ -507,8 +508,10 @@ impl TwoStageDrain {
             line_count_processed: 0, // Initialize new field
         })
     }
+}
 
-    pub fn process_line(&mut self, line: String) -> Result<bool, Error> {
+impl Drain for TwoStageDrain {
+    fn process_line(&mut self, line: String) -> Result<bool, Error> {
         let local_max_depth = self.max_depth;
         let local_max_children = self.max_children;
         let local_threshold = self.threshold.clone();
@@ -621,10 +624,14 @@ impl TwoStageDrain {
         Ok(true) // Created new group
     }
 
-    pub fn collect_all_log_groups(&self) -> Vec<LogGroup> {
+    fn collect_log_groups(&self) -> Vec<LogGroup> {
         let mut all_groups = Vec::new();
         for node in self.tree.values() {
-            Self::collect_groups_recursive(node, &mut all_groups);
+            // Assuming collect_groups_recursive is a static/helper method or defined on Self
+            // If it's an instance method, it would be self.collect_groups_recursive
+            // Based on its usage elsewhere (Self::), it's likely a static helper or associated function
+            // that can be called like this.
+            TwoStageDrain::collect_groups_recursive(node, &mut all_groups);
         }
         all_groups
     }

--- a/src/drains/two_stage_drain.rs
+++ b/src/drains/two_stage_drain.rs
@@ -97,8 +97,11 @@ mod tests {
     #[test]
     fn test_process_line_creates_new_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
-        assert_that(&Drain::process_line(&mut drain, "This is a test log line".to_string()))
-            .is_ok_containing(true);
+        assert_that(&Drain::process_line(
+            &mut drain,
+            "This is a test log line".to_string(),
+        ))
+        .is_ok_containing(true);
     }
 
     #[traced_test]
@@ -106,8 +109,11 @@ mod tests {
     fn test_process_line_matches_existing_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 10, 10).unwrap(); // Increased max_depth for this test
         let _ = Drain::process_line(&mut drain, "Log message type A value1".to_string());
-        assert_that(&Drain::process_line(&mut drain, "Log message type A value2".to_string()))
-            .is_ok_containing(false);
+        assert_that(&Drain::process_line(
+            &mut drain,
+            "Log message type A value2".to_string(),
+        ))
+        .is_ok_containing(false);
     }
 
     #[traced_test]
@@ -115,8 +121,11 @@ mod tests {
     fn test_process_line_creates_second_group() {
         let mut drain = TwoStageDrain::new(vec![], 0.5, 4, 10).unwrap();
         let _ = Drain::process_line(&mut drain, "Log message type A value1".to_string());
-        assert_that(&Drain::process_line(&mut drain, "Completely different log message valueX".to_string()))
-            .is_ok_containing(true);
+        assert_that(&Drain::process_line(
+            &mut drain,
+            "Completely different log message valueX".to_string(),
+        ))
+        .is_ok_containing(true);
     }
 
     #[traced_test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,18 @@ pub mod record;
 
 /// # Log Querying
 ///
-/// This module provides structures and functions for querying processed log data that has
-/// been structured into `LogGroup`s. The primary structure for accessing and managing
-/// this data is the `LogStore`.
+/// This module provides structures and functions for querying processed log data.
+/// Log data is structured into `LogGroup`s, which are collections of similar log records.
+/// The primary structure for querying this data is the [`query::LogStore`].
+///
+/// The `LogStore` is generic and operates on data provided by a [`drains::api::Drain`]
+/// implementation. This means it doesn't own the log data directly but rather queries
+/// it from the underlying drain.
 ///
 /// Key functionalities include:
-/// - Storing and retrieving `LogGroup`s by their unique ID.
-/// - Filtering `LogGroup`s based on a specific time range.
-/// - Performing range-based aggregation on the example records of a specific `LogGroup`
-///   (identified by its ID) via the `query::query_log_range_aggregation` function.
-///   This allows for detailed analysis of log events matching a particular pattern
-///   within a given time window.
+/// - Retrieving `LogGroup`s by their unique ID via the `LogStore`.
+/// - Filtering `LogGroup`s based on a specific time range using the `LogStore`.
+/// - Executing LogQL queries against the `LogStore` using [`query::execute_logql_query`].
+/// - Performing range-based aggregation on records (from specific log groups or LogQL queries)
+///   within a given time window, facilitated by [`query::query_log_range_aggregation`].
 pub mod query;

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -157,7 +157,7 @@ impl fmt::Display for LogGroup {
         write!(
             f,
             "LogGroup ID: {}\nFirst Seen: {}\nEvent: {}\n{} examples and {} wildcards\n",
-            self.event.uid, // Changed from serialize()
+            self.event.uid,  // Changed from serialize()
             self.get_time(), // Changed from self.event.uid.get_time() to use the struct's method
             self.event,
             self.examples.len(),

--- a/src/query.rs
+++ b/src/query.rs
@@ -44,7 +44,7 @@ impl<D: Drain> LogStore<D> {
     /// # Parameters
     ///
     /// * `drain`: An instance of a type implementing the `Drain` trait, which will
-    ///            serve as the source of log data for this store.
+    ///   serve as the source of log data for this store.
     pub fn new(drain: D) -> Self {
         Self { drain }
     }
@@ -196,7 +196,8 @@ pub fn query_log_range_aggregation<D: Drain>(
         QuerySource::ById(group_id) => {
             log_store.get_log_group_by_id(group_id).map_or_else(
                 Vec::new, // If group not found, return empty vec
-                |log_group| { // If group found, collect its records (cloned)
+                |log_group| {
+                    // If group found, collect its records (cloned)
                     let mut records = vec![log_group.base_record().clone()];
                     records.extend(log_group.examples().iter().cloned());
                     records
@@ -210,7 +211,8 @@ pub fn query_log_range_aggregation<D: Drain>(
 
     initial_records
         .into_iter()
-        .filter(|record| { // record is now Record, not &Record
+        .filter(|record| {
+            // record is now Record, not &Record
             record.uid.get_timestamp().is_some_and(|ts| {
                 let (secs_u64, nanos) = ts.to_unix();
                 let secs_i64 = secs_u64 as i64;
@@ -236,7 +238,7 @@ mod tests {
     use std::thread::sleep;
     use std::time::Duration as StdDuration;
     use uuid::{Uuid, Version}; // Added for proptest
-    // Removed unused import: use crate::drains::simple::SingleLayer;
+                               // Removed unused import: use crate::drains::simple::SingleLayer;
 
     // Helper to create a record and get its timestamp
     fn get_record_timestamp(record: &Record) -> Option<DateTime<Utc>> {
@@ -257,7 +259,7 @@ mod tests {
 
     // Strategy for Record
     fn arb_record() -> impl Strategy<Value = Record> {
-        arb_record_content().prop_map(|content| Record::new(content))
+        arb_record_content().prop_map(Record::new)
     }
 
     // Strategy for LineFilter
@@ -400,7 +402,9 @@ mod tests {
 
     impl MockDrain {
         fn new() -> Self {
-            Self { groups: HashMap::new() }
+            Self {
+                groups: HashMap::new(),
+            }
         }
 
         #[allow(dead_code)] // This method is used in tests that might be temporarily commented out
@@ -420,7 +424,6 @@ mod tests {
         }
     }
 
-
     #[test]
     fn test_log_store_new() {
         let mock_drain = MockDrain::new();
@@ -429,9 +432,13 @@ mod tests {
         // Further checks depend on how LogStore interacts with Drain,
         // e.g., if it immediately collects groups or does so on demand.
         // For now, just ensuring it can be created.
-        assert!(store.get_log_groups_in_range(Utc::now(), Utc::now()).is_empty(), "New LogStore with empty drain should have no groups in range");
+        assert!(
+            store
+                .get_log_groups_in_range(Utc::now(), Utc::now())
+                .is_empty(),
+            "New LogStore with empty drain should have no groups in range"
+        );
     }
-
 
     #[test]
     fn test_log_store_get_by_id() {
@@ -442,7 +449,6 @@ mod tests {
         let mut mock_drain = MockDrain::new();
         mock_drain.add_group(group1.clone()); // Clone group1 as it's used later
         let store = LogStore::new(mock_drain);
-
 
         let found_group = store.get_log_group_by_id(id1);
         assert!(found_group.is_some(), "Should find existing group by ID");
@@ -484,7 +490,12 @@ mod tests {
         assert!(time2 < time3, "time2 should be less than time3");
 
         let all_groups = store.get_log_groups_in_range(time1, time3);
-        assert_eq!(all_groups.len(), 3, "Should find all 3 groups. Found: {:?}", all_groups.iter().map(|g| g.id).collect::<Vec<_>>());
+        assert_eq!(
+            all_groups.len(),
+            3,
+            "Should find all 3 groups. Found: {:?}",
+            all_groups.iter().map(|g| g.id).collect::<Vec<_>>()
+        );
 
         let some_groups_middle = store.get_log_groups_in_range(
             time1 + ChronoDuration::milliseconds(50),
@@ -493,37 +504,55 @@ mod tests {
         assert_eq!(some_groups_middle.len(), 1, "Should find 1 group (g2)");
         assert_eq!(some_groups_middle[0].id, g2.id);
 
-
         let some_groups_first_two = store.get_log_groups_in_range(time1, time2);
-        assert_eq!(some_groups_first_two.len(), 2, "Should find 2 groups (g1, g2)");
-
+        assert_eq!(
+            some_groups_first_two.len(),
+            2,
+            "Should find 2 groups (g1, g2)"
+        );
 
         let no_groups_before = store.get_log_groups_in_range(
             base_time - ChronoDuration::seconds(10),
             base_time - ChronoDuration::seconds(5),
         );
-        assert_eq!(no_groups_before.len(), 0, "Should find no groups (range before all)");
-
+        assert_eq!(
+            no_groups_before.len(),
+            0,
+            "Should find no groups (range before all)"
+        );
 
         let no_groups_after = store.get_log_groups_in_range(
             time3 + ChronoDuration::seconds(5),
             time3 + ChronoDuration::seconds(10),
         );
-        assert_eq!(no_groups_after.len(), 0, "Should find no groups (range after all)");
-
+        assert_eq!(
+            no_groups_after.len(),
+            0,
+            "Should find no groups (range after all)"
+        );
 
         let exact_match_g2 = store.get_log_groups_in_range(time2, time2);
-        assert_eq!(exact_match_g2.len(), 1, "Should find g2 with exact time match");
+        assert_eq!(
+            exact_match_g2.len(),
+            1,
+            "Should find g2 with exact time match"
+        );
         assert_eq!(exact_match_g2[0].id, g2.id);
 
-
         let edge_start = store.get_log_groups_in_range(time1, time1);
-        assert_eq!(edge_start.len(), 1, "Should find g1 when it's exactly on start_time");
+        assert_eq!(
+            edge_start.len(),
+            1,
+            "Should find g1 when it's exactly on start_time"
+        );
         assert_eq!(edge_start[0].id, g1.id);
 
-
         let edge_end = store.get_log_groups_in_range(time3, time3);
-        assert_eq!(edge_end.len(), 1, "Should find g3 when it's exactly on end_time");
+        assert_eq!(
+            edge_end.len(),
+            1,
+            "Should find g3 when it's exactly on end_time"
+        );
         assert_eq!(edge_end[0].id, g3.id);
     }
 
@@ -552,19 +581,17 @@ mod tests {
         mock_drain.add_group(log_group);
         let store = LogStore::new(mock_drain);
 
-
         let non_existent_id = Uuid::new_v4();
         let results_not_found = query_log_range_aggregation(
             &store, // LogStore<MockDrain>
             QuerySource::ById(non_existent_id),
-            base_time, // DateTime<Utc>
-            Utc::now(),  // DateTime<Utc>
+            base_time,  // DateTime<Utc>
+            Utc::now(), // DateTime<Utc>
         );
         assert!(
             results_not_found.is_empty(),
             "Should return empty for non-existent group ID"
         );
-
 
         let results_none_in_range = query_log_range_aggregation(
             &store,
@@ -576,7 +603,6 @@ mod tests {
             results_none_in_range.is_empty(),
             "Should return empty if no records in time range"
         );
-
 
         let results_some_in_range = query_log_range_aggregation(
             &store,
@@ -594,7 +620,6 @@ mod tests {
             time2
         );
 
-
         let results_all_in_range =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time1, time3);
         assert_eq!(
@@ -602,7 +627,6 @@ mod tests {
             3,
             "Should find all 3 records in the range"
         );
-
 
         let results_edge_start =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time1, time1);
@@ -612,7 +636,6 @@ mod tests {
             "Should find record 1 when it is exactly on start_time"
         );
         assert_eq!(get_record_timestamp(&results_edge_start[0]).unwrap(), time1); // Added &
-
 
         let results_edge_end =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time3, time3);
@@ -654,11 +677,9 @@ mod tests {
             for record_in_result in &results {
                 let mut record_belongs_to_a_selected_group = false;
                 for group in &log_groups_vec { // Use log_groups_vec here
-                    if selected_group_ids_set.contains(&group.id) {
-                        if group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid) {
-                            record_belongs_to_a_selected_group = true;
-                            break;
-                        }
+                    if selected_group_ids_set.contains(&group.id) && (group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid)) {
+                        record_belongs_to_a_selected_group = true;
+                        break;
                     }
                 }
                 prop_assert!(record_belongs_to_a_selected_group, "Record {} from results (content: '{}') does not belong to any selected group. Selected groups: {:?}", record_in_result.uid, record_in_result.to_string(), selected_group_ids_set);
@@ -674,7 +695,7 @@ mod tests {
                     let mut records_to_check = group.examples().clone();
                     records_to_check.push(group.base_record().clone());
                     for original_record in records_to_check {
-                        let matches_filter = query.filter.as_ref().map_or(true, |f| original_record.to_string().contains(&f.contains));
+                        let matches_filter = query.filter.as_ref().is_none_or(|f| original_record.to_string().contains(&f.contains));
                         if matches_filter {
                             prop_assert!(results.iter().any(|res_rec| res_rec.uid == original_record.uid),
                                          "Original record {} (content: '{}') from group {} matches filter but not found in results. Filter: {:?}", original_record.uid, original_record.to_string(), group.id, query.filter.as_ref().map(|f| &f.contains));
@@ -704,11 +725,9 @@ mod tests {
             for record_in_result in &results {
                 let mut record_belongs_to_a_selected_group = false;
                 for group in &log_groups_vec { // Use log_groups_vec here
-                    if selected_group_ids_set.contains(&group.id) {
-                        if group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid) {
-                            record_belongs_to_a_selected_group = true;
-                            break;
-                        }
+                    if selected_group_ids_set.contains(&group.id) && (group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid)) {
+                        record_belongs_to_a_selected_group = true;
+                        break;
                     }
                 }
                 prop_assert!(record_belongs_to_a_selected_group, "Record {} from results (content: '{}') does not belong to selected group. Selected: {:?}", record_in_result.uid, record_in_result.to_string(), selected_group_ids_set);
@@ -729,7 +748,7 @@ mod tests {
                     records_to_check.push(group.base_record().clone());
 
                     for original_record in records_to_check {
-                        let matches_filter = query.filter.as_ref().map_or(true, |f| original_record.to_string().contains(&f.contains));
+                        let matches_filter = query.filter.as_ref().is_none_or(|f| original_record.to_string().contains(&f.contains));
                         let record_time_option = get_record_timestamp(&original_record);
                         prop_assert!(record_time_option.is_some(), "Original record {} (content: '{}') must have a timestamp for time range check.", original_record.uid, original_record.to_string());
                         let record_time = record_time_option.unwrap();

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,53 +8,93 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
+//! # Log Querying System
+//!
+//! This module provides structures and functions for querying log data.
+//! The central component is the [`LogStore`], which acts as an abstraction layer
+//! over a log data source, represented by an implementation of the [`Drain`](crate::drains::api::Drain) trait.
+//!
+//! It also defines LogQL (Log Query Language) related structures like [`LogQlQuery`],
+//! [`StreamSelector`], and [`LineFilter`] to enable structured querying of logs.
+
+use crate::drains::api::Drain;
 use crate::log_group::LogGroup;
 use crate::record::Record;
 use chrono::{DateTime, Utc};
-use std::collections::HashMap;
+// Removed HashMap import as log_groups field is removed
 use uuid::Uuid; // Added for function return type and usage
 
+/// A generic log data store that interacts with a log source via the [`Drain`] trait.
+///
+/// `LogStore` provides an interface to query log groups and records. It is generic
+/// over `D: Drain`, meaning it can work with any concrete drain implementation
+/// that provides log data (e.g., in-memory drains, file-based drains).
+///
+/// Log groups are fetched dynamically from the underlying drain when queried.
 #[derive(Debug, Clone)]
-pub struct LogStore {
-    log_groups: HashMap<Uuid, LogGroup>,
+pub struct LogStore<D: Drain> {
+    drain: D,
 }
 
-impl Default for LogStore {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+// Default implementation removed as Drain doesn't have a Default bound
 
-impl LogStore {
-    pub fn new() -> Self {
-        Self {
-            log_groups: HashMap::new(),
-        }
-    }
-
-    pub fn add_log_group(&mut self, log_group: LogGroup) {
-        self.log_groups.insert(log_group.id, log_group);
+impl<D: Drain> LogStore<D> {
+    /// Creates a new `LogStore` with the given drain.
+    ///
+    /// # Parameters
+    ///
+    /// * `drain`: An instance of a type implementing the `Drain` trait, which will
+    ///            serve as the source of log data for this store.
+    pub fn new(drain: D) -> Self {
+        Self { drain }
     }
 
-    pub fn from_log_groups(groups: impl IntoIterator<Item = LogGroup>) -> Self {
-        let mut store = Self::new();
-        for group in groups {
-            store.add_log_group(group);
-        }
-        store
+    // add_log_group removed as LogStore is initialized with a Drain instance
+
+    // from_log_groups removed as LogStore is initialized with a Drain instance
+
+    /// Retrieves a specific `LogGroup` by its ID.
+    ///
+    /// This method queries the underlying drain for all its log groups and then
+    /// searches for the one with the matching ID.
+    ///
+    /// # Parameters
+    ///
+    /// * `id`: The `Uuid` of the `LogGroup` to retrieve.
+    ///
+    /// # Returns
+    ///
+    /// An `Option<LogGroup>` containing the found log group, or `None` if no
+    /// group with the specified ID exists in the drain. The `LogGroup` is returned by value.
+    pub fn get_log_group_by_id(&self, id: Uuid) -> Option<LogGroup> {
+        self.drain
+            .collect_log_groups()
+            .into_iter()
+            .find(|lg| lg.id == id)
     }
 
-    pub fn get_log_group_by_id(&self, id: Uuid) -> Option<&LogGroup> {
-        self.log_groups.get(&id)
-    }
-
+    /// Retrieves all `LogGroup`s that fall within a specified time range.
+    ///
+    /// This method queries the underlying drain for all its log groups and then
+    /// filters them based on their timestamp.
+    ///
+    /// # Parameters
+    ///
+    /// * `start_time`: The `DateTime<Utc>` marking the beginning of the time range (inclusive).
+    /// * `end_time`: The `DateTime<Utc>` marking the end of the time range (inclusive).
+    ///
+    /// # Returns
+    ///
+    /// A `Vec<LogGroup>` containing all log groups whose timestamp is within the
+    /// specified range. The `LogGroup`s are returned by value.
     pub fn get_log_groups_in_range(
         &self,
         start_time: DateTime<Utc>,
         end_time: DateTime<Utc>,
-    ) -> Vec<&LogGroup> {
-        self.log_groups
-            .values()
+    ) -> Vec<LogGroup> {
+        self.drain
+            .collect_log_groups()
+            .into_iter()
             .filter(|log_group| {
                 let timestamp = log_group.get_time();
                 timestamp >= start_time && timestamp <= end_time
@@ -87,15 +127,34 @@ pub enum QuerySource {
     // This was part of the original definitions to be restored
 }
 
-pub fn execute_logql_query<'a>(log_store: &'a LogStore, query: &LogQlQuery) -> Vec<&'a Record> {
-    let mut records_batch: Vec<&'a Record> = Vec::new();
+/// Executes a LogQL query against the provided `LogStore`.
+///
+/// This function processes a [`LogQlQuery`], retrieving records from the specified
+/// log groups and applying any defined filters. It is generic over `D: Drain`
+/// because `LogStore` is generic.
+///
+/// Due to lifetime considerations with the `Drain` trait (which returns owned `LogGroup`s),
+/// this function returns a `Vec<Record>` (i.e., cloned, owned records) rather than references.
+///
+/// # Parameters
+///
+/// * `log_store`: A reference to the `LogStore` instance to query.
+/// * `query`: A reference to the `LogQlQuery` defining the selection and filtering criteria.
+///
+/// # Returns
+///
+/// A `Vec<Record>` containing all records that match the query criteria.
+pub fn execute_logql_query<D: Drain>(log_store: &LogStore<D>, query: &LogQlQuery) -> Vec<Record> {
+    let mut records_batch: Vec<Record> = Vec::new();
+
+    let collected_groups = log_store.drain.collect_log_groups();
 
     match &query.selector {
         StreamSelector::LogGroupIds(group_ids) => {
             for group_id in group_ids {
-                if let Some(log_group) = log_store.get_log_group_by_id(*group_id) {
-                    records_batch.push(log_group.base_record()); // Add the base record
-                    records_batch.extend(log_group.examples().iter()); // Add all example records
+                if let Some(log_group) = collected_groups.iter().find(|lg| lg.id == *group_id) {
+                    records_batch.push(log_group.base_record().clone()); // Clone base record
+                    records_batch.extend(log_group.examples().iter().cloned()); // Clone example records
                 }
             }
         }
@@ -108,31 +167,50 @@ pub fn execute_logql_query<'a>(log_store: &'a LogStore, query: &LogQlQuery) -> V
     records_batch
 }
 
-pub fn query_log_range_aggregation<'a>(
-    log_store: &'a LogStore,
-    query_source: QuerySource, // Changed parameter
+/// Aggregates log records based on a query source and a time range.
+///
+/// This function retrieves records either by a specific log group ID or by a LogQL query,
+/// and then filters these records to include only those within the specified time range.
+/// It is generic over `D: Drain` due to its use of `LogStore`.
+///
+/// Similar to `execute_logql_query`, this function returns `Vec<Record>` (cloned records)
+/// to manage lifetimes correctly with data sourced from the `Drain`.
+///
+/// # Parameters
+///
+/// * `log_store`: A reference to the `LogStore` instance.
+/// * `query_source`: A [`QuerySource`] enum indicating whether to fetch records by ID or by a LogQL query.
+/// * `start_time`: The `DateTime<Utc>` start of the aggregation range.
+/// * `end_time`: The `DateTime<Utc>` end of the aggregation range.
+///
+/// # Returns
+///
+/// A `Vec<Record>` containing all records that match the query source and fall within the time range.
+pub fn query_log_range_aggregation<D: Drain>(
+    log_store: &LogStore<D>,
+    query_source: QuerySource,
     start_time: DateTime<Utc>,
     end_time: DateTime<Utc>,
-) -> Vec<&'a Record> {
-    let initial_records: Vec<&'a Record> = match query_source {
+) -> Vec<Record> {
+    let initial_records: Vec<Record> = match query_source {
         QuerySource::ById(group_id) => {
-            log_store
-                .get_log_group_by_id(group_id)
-                .map_or(vec![], |log_group| {
-                    let mut records = vec![log_group.base_record()];
-                    records.extend(log_group.examples().iter());
+            log_store.get_log_group_by_id(group_id).map_or_else(
+                Vec::new, // If group not found, return empty vec
+                |log_group| { // If group found, collect its records (cloned)
+                    let mut records = vec![log_group.base_record().clone()];
+                    records.extend(log_group.examples().iter().cloned());
                     records
-                })
+                },
+            )
         }
         QuerySource::ByLogQl(logql_query) => {
-            // Ensure execute_logql_query is called with a reference
-            execute_logql_query(log_store, &logql_query)
+            execute_logql_query(log_store, &logql_query) // Already returns Vec<Record>
         }
     };
 
     initial_records
         .into_iter()
-        .filter(|record| {
+        .filter(|record| { // record is now Record, not &Record
             record.uid.get_timestamp().is_some_and(|ts| {
                 let (secs_u64, nanos) = ts.to_unix();
                 let secs_i64 = secs_u64 as i64;
@@ -154,10 +232,11 @@ mod tests {
     use proptest::collection::vec as prop_vec; // Added for proptest
     use proptest::prelude::*; // Added for proptest
     use proptest::sample::subsequence; // Added for subsequence
-    use std::collections::HashSet; // Added for proptest
+    use std::collections::{HashMap, HashSet}; // Added for proptest, HashMap for mock drain
     use std::thread::sleep;
     use std::time::Duration as StdDuration;
     use uuid::{Uuid, Version}; // Added for proptest
+    // Removed unused import: use crate::drains::simple::SingleLayer;
 
     // Helper to create a record and get its timestamp
     fn get_record_timestamp(record: &Record) -> Option<DateTime<Utc>> {
@@ -313,62 +392,46 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_log_store_new_and_add() {
-        let mut store = LogStore::new();
-        assert_eq!(store.log_groups.len(), 0, "New LogStore should be empty");
-
-        let record = Record::new("Test record for new_and_add".to_string());
-        let log_group = LogGroup::new(record);
-        let group_id = log_group.id;
-
-        store.add_log_group(log_group);
-        assert_eq!(
-            store.log_groups.len(),
-            1,
-            "LogStore should have one group after adding"
-        );
-
-        let retrieved_group = store.get_log_group_by_id(group_id);
-        assert!(
-            retrieved_group.is_some(),
-            "Should retrieve the added log group"
-        );
-        assert_eq!(
-            retrieved_group.unwrap().id,
-            group_id,
-            "Retrieved group ID should match"
-        );
+    // Mock Drain for testing LogStore
+    #[derive(Clone)] // Added Clone
+    struct MockDrain {
+        groups: HashMap<Uuid, LogGroup>,
     }
 
-    #[test]
-    fn test_log_store_from_log_groups() {
-        let record1 = Record::new("Record 1 for from_log_groups".to_string());
-        let group1 = LogGroup::new(record1);
-        let id1 = group1.id;
+    impl MockDrain {
+        fn new() -> Self {
+            Self { groups: HashMap::new() }
+        }
 
-        sleep(StdDuration::from_millis(10));
-        let record2 = Record::new("Record 2 for from_log_groups".to_string());
-        let group2 = LogGroup::new(record2);
-        let id2 = group2.id;
-
-        let groups = vec![group1, group2]; // group1 and group2 are moved here
-        let store = LogStore::from_log_groups(groups);
-
-        assert_eq!(
-            store.log_groups.len(),
-            2,
-            "LogStore should contain two groups"
-        );
-        assert!(
-            store.get_log_group_by_id(id1).is_some(),
-            "Group 1 should be in the store"
-        );
-        assert!(
-            store.get_log_group_by_id(id2).is_some(),
-            "Group 2 should be in the store"
-        );
+        #[allow(dead_code)] // This method is used in tests that might be temporarily commented out
+        fn add_group(&mut self, group: LogGroup) {
+            self.groups.insert(group.id, group);
+        }
     }
+
+    impl Drain for MockDrain {
+        fn process_line(&mut self, _line: String) -> anyhow::Result<bool> {
+            // Not used in these LogStore tests
+            Ok(false)
+        }
+
+        fn collect_log_groups(&self) -> Vec<LogGroup> {
+            self.groups.values().cloned().collect()
+        }
+    }
+
+
+    #[test]
+    fn test_log_store_new() {
+        let mock_drain = MockDrain::new();
+        let store = LogStore::new(mock_drain);
+        // Basic check: new store with an empty drain should yield no groups.
+        // Further checks depend on how LogStore interacts with Drain,
+        // e.g., if it immediately collects groups or does so on demand.
+        // For now, just ensuring it can be created.
+        assert!(store.get_log_groups_in_range(Utc::now(), Utc::now()).is_empty(), "New LogStore with empty drain should have no groups in range");
+    }
+
 
     #[test]
     fn test_log_store_get_by_id() {
@@ -376,13 +439,16 @@ mod tests {
         let group1 = LogGroup::new(record1);
         let id1 = group1.id;
 
-        let store = LogStore::from_log_groups(vec![group1]);
+        let mut mock_drain = MockDrain::new();
+        mock_drain.add_group(group1.clone()); // Clone group1 as it's used later
+        let store = LogStore::new(mock_drain);
+
 
         let found_group = store.get_log_group_by_id(id1);
         assert!(found_group.is_some(), "Should find existing group by ID");
         assert_eq!(found_group.unwrap().id, id1);
 
-        let non_existent_id = Uuid::new_v4(); // Different type of UUID, but fine for testing non-existence
+        let non_existent_id = Uuid::new_v4();
         let not_found_group = store.get_log_group_by_id(non_existent_id);
         assert!(
             not_found_group.is_none(),
@@ -392,161 +458,114 @@ mod tests {
 
     #[test]
     fn test_log_store_get_in_range() {
-        let mut groups_to_add = Vec::new();
+        let mut mock_drain = MockDrain::new();
         let base_time = Utc::now();
 
-        // Create groups with timestamps approximately 100ms apart
         let r1 = Record::new("g1".to_string());
-        let g1 = LogGroup::new(r1); // ~base_time
-        let id1 = g1.id;
-        groups_to_add.push(g1);
-        sleep(StdDuration::from_millis(100));
+        let g1 = LogGroup::new(r1);
+        let time1 = g1.get_time();
+        mock_drain.add_group(g1.clone());
+        sleep(StdDuration::from_millis(100)); // Ensure timestamps are distinct
 
         let r2 = Record::new("g2".to_string());
-        let g2 = LogGroup::new(r2); // ~base_time + 100ms
-        let id2 = g2.id;
-        groups_to_add.push(g2);
+        let g2 = LogGroup::new(r2);
+        let time2 = g2.get_time();
+        mock_drain.add_group(g2.clone());
         sleep(StdDuration::from_millis(100));
 
         let r3 = Record::new("g3".to_string());
-        let g3 = LogGroup::new(r3); // ~base_time + 200ms
-        let id3 = g3.id;
-        groups_to_add.push(g3);
+        let g3 = LogGroup::new(r3);
+        let time3 = g3.get_time();
+        mock_drain.add_group(g3.clone());
 
-        let store = LogStore::from_log_groups(groups_to_add);
+        let store = LogStore::new(mock_drain);
 
-        // Fetch the actual stored groups by their original IDs to get their correct timestamps
-        let stored_g1 = store
-            .get_log_group_by_id(id1)
-            .expect("g1 not found in store");
-        let time1 = stored_g1.get_time();
-        let stored_g2 = store
-            .get_log_group_by_id(id2)
-            .expect("g2 not found in store");
-        let time2 = stored_g2.get_time();
-        let stored_g3 = store
-            .get_log_group_by_id(id3)
-            .expect("g3 not found in store");
-        let time3 = stored_g3.get_time();
-
-        // Ensure times are ordered as expected due to sleep, with some tolerance
         assert!(time1 < time2, "time1 should be less than time2");
         assert!(time2 < time3, "time2 should be less than time3");
 
-        // Scenario 1: Range includes all
         let all_groups = store.get_log_groups_in_range(time1, time3);
-        assert_eq!(
-            all_groups.len(),
-            3,
-            "Should find all 3 groups. Found: {:?}",
-            all_groups.iter().map(|g| g.id).collect::<Vec<_>>()
-        );
+        assert_eq!(all_groups.len(), 3, "Should find all 3 groups. Found: {:?}", all_groups.iter().map(|g| g.id).collect::<Vec<_>>());
 
-        // Scenario 2: Range includes some (middle one)
         let some_groups_middle = store.get_log_groups_in_range(
             time1 + ChronoDuration::milliseconds(50),
             time3 - ChronoDuration::milliseconds(50),
         );
         assert_eq!(some_groups_middle.len(), 1, "Should find 1 group (g2)");
-        assert_eq!(some_groups_middle[0].id, stored_g2.id);
+        assert_eq!(some_groups_middle[0].id, g2.id);
 
-        // Scenario 3: Range includes some (first two)
+
         let some_groups_first_two = store.get_log_groups_in_range(time1, time2);
-        assert_eq!(
-            some_groups_first_two.len(),
-            2,
-            "Should find 2 groups (g1, g2)"
-        );
+        assert_eq!(some_groups_first_two.len(), 2, "Should find 2 groups (g1, g2)");
 
-        // Scenario 4: Range includes none (before all)
+
         let no_groups_before = store.get_log_groups_in_range(
             base_time - ChronoDuration::seconds(10),
             base_time - ChronoDuration::seconds(5),
         );
-        assert_eq!(
-            no_groups_before.len(),
-            0,
-            "Should find no groups (range before all)"
-        );
+        assert_eq!(no_groups_before.len(), 0, "Should find no groups (range before all)");
 
-        // Scenario 5: Range includes none (after all)
+
         let no_groups_after = store.get_log_groups_in_range(
             time3 + ChronoDuration::seconds(5),
             time3 + ChronoDuration::seconds(10),
         );
-        assert_eq!(
-            no_groups_after.len(),
-            0,
-            "Should find no groups (range after all)"
-        );
+        assert_eq!(no_groups_after.len(), 0, "Should find no groups (range after all)");
 
-        // Scenario 6: Range is start_time == end_time (exact match for g2)
+
         let exact_match_g2 = store.get_log_groups_in_range(time2, time2);
-        assert_eq!(
-            exact_match_g2.len(),
-            1,
-            "Should find g2 with exact time match"
-        );
-        assert_eq!(exact_match_g2[0].id, stored_g2.id);
+        assert_eq!(exact_match_g2.len(), 1, "Should find g2 with exact time match");
+        assert_eq!(exact_match_g2[0].id, g2.id);
 
-        // Scenario 7: Edge case - g1 exactly on start_time
+
         let edge_start = store.get_log_groups_in_range(time1, time1);
-        assert_eq!(
-            edge_start.len(),
-            1,
-            "Should find g1 when it's exactly on start_time"
-        );
-        assert_eq!(edge_start[0].id, stored_g1.id);
+        assert_eq!(edge_start.len(), 1, "Should find g1 when it's exactly on start_time");
+        assert_eq!(edge_start[0].id, g1.id);
 
-        // Scenario 8: Edge case - g3 exactly on end_time
+
         let edge_end = store.get_log_groups_in_range(time3, time3);
-        assert_eq!(
-            edge_end.len(),
-            1,
-            "Should find g3 when it's exactly on end_time"
-        );
-        assert_eq!(edge_end[0].id, stored_g3.id);
+        assert_eq!(edge_end.len(), 1, "Should find g3 when it's exactly on end_time");
+        assert_eq!(edge_end[0].id, g3.id);
     }
 
     #[test]
     fn test_query_log_range_aggregation() {
-        let mut store = LogStore::new();
+        let mut mock_drain = MockDrain::new();
         let record_template = Record::new("Log group for aggregation test".to_string());
         let mut log_group = LogGroup::new(record_template);
         let group_id = log_group.id;
         let base_time = Utc::now();
 
-        // Create example records with varying timestamps
-        let ex_r1 = Record::new("Example 1".to_string()); // ~base_time
+        let ex_r1 = Record::new("Example 1".to_string());
         let time1 = get_record_timestamp(&ex_r1).unwrap();
         log_group.add_example(ex_r1);
         sleep(StdDuration::from_millis(50));
 
-        let ex_r2 = Record::new("Example 2".to_string()); // ~base_time + 50ms
+        let ex_r2 = Record::new("Example 2".to_string());
         let time2 = get_record_timestamp(&ex_r2).unwrap();
         log_group.add_example(ex_r2);
         sleep(StdDuration::from_millis(50));
 
-        let ex_r3 = Record::new("Example 3".to_string()); // ~base_time + 100ms
+        let ex_r3 = Record::new("Example 3".to_string());
         let time3 = get_record_timestamp(&ex_r3).unwrap();
         log_group.add_example(ex_r3);
 
-        store.add_log_group(log_group);
+        mock_drain.add_group(log_group);
+        let store = LogStore::new(mock_drain);
 
-        // Scenario 1: Group ID not found
+
         let non_existent_id = Uuid::new_v4();
         let results_not_found = query_log_range_aggregation(
-            &store,
+            &store, // LogStore<MockDrain>
             QuerySource::ById(non_existent_id),
-            base_time,
-            Utc::now(),
+            base_time, // DateTime<Utc>
+            Utc::now(),  // DateTime<Utc>
         );
         assert!(
             results_not_found.is_empty(),
             "Should return empty for non-existent group ID"
         );
 
-        // Scenario 2: Group ID found, but no records in the time range
+
         let results_none_in_range = query_log_range_aggregation(
             &store,
             QuerySource::ById(group_id),
@@ -558,12 +577,12 @@ mod tests {
             "Should return empty if no records in time range"
         );
 
-        // Scenario 3: Group ID found, some records in the time range (middle one)
+
         let results_some_in_range = query_log_range_aggregation(
             &store,
             QuerySource::ById(group_id),
-            time1 + ChronoDuration::milliseconds(25),
-            time3 - ChronoDuration::milliseconds(25),
+            time1 + ChronoDuration::milliseconds(25), // start_time
+            time3 - ChronoDuration::milliseconds(25), // end_time
         );
         assert_eq!(
             results_some_in_range.len(),
@@ -571,11 +590,11 @@ mod tests {
             "Should find 1 record in the middle of the range"
         );
         assert_eq!(
-            get_record_timestamp(results_some_in_range[0]).unwrap(),
+            get_record_timestamp(&results_some_in_range[0]).unwrap(), // Added &
             time2
         );
 
-        // Scenario 4: Group ID found, all records in the time range
+
         let results_all_in_range =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time1, time3);
         assert_eq!(
@@ -584,8 +603,7 @@ mod tests {
             "Should find all 3 records in the range"
         );
 
-        // Scenario 5: Edge cases for time ranges
-        // Record 1 exactly on start_time
+
         let results_edge_start =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time1, time1);
         assert_eq!(
@@ -593,9 +611,9 @@ mod tests {
             1,
             "Should find record 1 when it is exactly on start_time"
         );
-        assert_eq!(get_record_timestamp(results_edge_start[0]).unwrap(), time1);
+        assert_eq!(get_record_timestamp(&results_edge_start[0]).unwrap(), time1); // Added &
 
-        // Record 3 exactly on end_time
+
         let results_edge_end =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time3, time3);
         assert_eq!(
@@ -603,26 +621,31 @@ mod tests {
             1,
             "Should find record 3 when it is exactly on end_time"
         );
-        assert_eq!(get_record_timestamp(results_edge_end[0]).unwrap(), time3);
+        assert_eq!(get_record_timestamp(&results_edge_end[0]).unwrap(), time3); // Added &
 
-        // Range that includes first two
         let results_first_two =
             query_log_range_aggregation(&store, QuerySource::ById(group_id), time1, time2);
         assert_eq!(results_first_two.len(), 2, "Should find first two records");
     }
 
     // --- Property Tests ---
+    // Helper function to create LogStore<MockDrain> from Vec<LogGroup>
+    fn log_store_from_mock_groups(groups: Vec<LogGroup>) -> LogStore<MockDrain> {
+        let mut drain = MockDrain::new();
+        for group in groups {
+            drain.add_group(group);
+        }
+        LogStore::new(drain)
+    }
+
     proptest! {
         #[test]
         fn prop_execute_logql_query(
-
-            (log_groups, query) in arb_log_groups_and_query()
+            (log_groups_vec, query) in arb_log_groups_and_query()
         ) {
-            let log_store = LogStore::from_log_groups(log_groups.clone()); // log_groups is already Vec<LogGroup>
+            // Use the helper to create LogStore with MockDrain
+            let log_store = log_store_from_mock_groups(log_groups_vec.clone());
             let results = execute_logql_query(&log_store, &query);
-
-            // The existing assertions rely on `log_groups` and `query` directly.
-            // This part of the test logic does not need to change.
 
             let selected_group_ids_set: HashSet<Uuid> = match &query.selector {
                 StreamSelector::LogGroupIds(ids) => ids.iter().cloned().collect(),
@@ -630,8 +653,7 @@ mod tests {
 
             for record_in_result in &results {
                 let mut record_belongs_to_a_selected_group = false;
-                // log_groups is Vec<LogGroup> from arb_log_groups_and_query
-                for group in &log_groups {
+                for group in &log_groups_vec { // Use log_groups_vec here
                     if selected_group_ids_set.contains(&group.id) {
                         if group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid) {
                             record_belongs_to_a_selected_group = true;
@@ -647,17 +669,16 @@ mod tests {
                 }
             }
 
-            for group in &log_groups {
+            for group in &log_groups_vec { // Use log_groups_vec here
                 if selected_group_ids_set.contains(&group.id) {
-                    let mut records_to_check = group.examples().clone(); // Clones Vec<Record>
-                    records_to_check.push(group.base_record().clone()); // Clones Record
+                    let mut records_to_check = group.examples().clone();
+                    records_to_check.push(group.base_record().clone());
                     for original_record in records_to_check {
                         let matches_filter = query.filter.as_ref().map_or(true, |f| original_record.to_string().contains(&f.contains));
                         if matches_filter {
                             prop_assert!(results.iter().any(|res_rec| res_rec.uid == original_record.uid),
                                          "Original record {} (content: '{}') from group {} matches filter but not found in results. Filter: {:?}", original_record.uid, original_record.to_string(), group.id, query.filter.as_ref().map(|f| &f.contains));
                         } else {
-                            // If it doesn't match the filter, it should not be in the results.
                             prop_assert!(!results.iter().any(|res_rec| res_rec.uid == original_record.uid),
                                          "Original record {} (content: '{}') from group {} does NOT match filter but IS found in results. Filter: {:?}", original_record.uid, original_record.to_string(), group.id, query.filter.as_ref().map(|f| &f.contains));
                         }
@@ -670,23 +691,19 @@ mod tests {
     proptest! {
         #[test]
         fn prop_query_log_range_aggregation_with_logql(
-
-            (log_groups, query, time1, time2) in arb_log_groups_query_and_times()
+            (log_groups_vec, query, time1, time2) in arb_log_groups_query_and_times()
         ) {
-            let log_store = LogStore::from_log_groups(log_groups.clone()); // log_groups is Vec<LogGroup>
+            let log_store = log_store_from_mock_groups(log_groups_vec.clone()); // Use helper
             let (start_time, end_time) = if time1 <= time2 { (time1, time2) } else { (time2, time1) };
             let results = query_log_range_aggregation(&log_store, QuerySource::ByLogQl(query.clone()), start_time, end_time);
 
-            // The existing assertions rely on `log_groups`, `query`, `start_time`, `end_time` directly.
-            // This part of the test logic does not need to change.
             let selected_group_ids_set: HashSet<Uuid> = match &query.selector {
                 StreamSelector::LogGroupIds(ids) => ids.iter().cloned().collect(),
             };
 
             for record_in_result in &results {
                 let mut record_belongs_to_a_selected_group = false;
-
-                for group in &log_groups { // log_groups is Vec<LogGroup>
+                for group in &log_groups_vec { // Use log_groups_vec here
                     if selected_group_ids_set.contains(&group.id) {
                         if group.base_record().uid == record_in_result.uid || group.examples().iter().any(|ex| ex.uid == record_in_result.uid) {
                             record_belongs_to_a_selected_group = true;
@@ -706,7 +723,7 @@ mod tests {
                              "Record time {:?} for {} (content: '{}') is outside range [{:?}, {:?}]", record_time, record_in_result.uid, record_in_result.to_string(), start_time, end_time);
             }
 
-            for group in &log_groups { // log_groups is Vec<LogGroup>
+            for group in &log_groups_vec { // Use log_groups_vec here
                 if selected_group_ids_set.contains(&group.id) {
                     let mut records_to_check = group.examples().clone();
                     records_to_check.push(group.base_record().clone());


### PR DESCRIPTION
This change introduces a `Drain` trait to define a common interface for log processing components. The `SingleLayer` and `TwoStageDrain` implementations have been updated to implement this trait.

The `LogStore` has been refactored to be generic over the `Drain` trait, fetching log groups from the underlying drain instance instead of storing them directly. This change promotes monomorphism and improves type safety.

LogQL query functions (`execute_logql_query` and `query_log_range_aggregation`) have been updated to work with the generic `LogStore`. To manage data lifetimes effectively with the new structure, these functions now return `Vec<Record>` (cloned data) instead of `Vec<&Record>`.

Existing tests for drains and query functionalities have been updated to align with these API changes, including the use of a `MockDrain` for testing the generic `LogStore`. Documentation across the affected modules has also been updated to reflect the new abstractions and usage patterns.