### PR TITLE
Use with_capacity for arc-string interner

### DIFF
--- a/src/intern_benchmark_harness/mod.rs
+++ b/src/intern_benchmark_harness/mod.rs
@@ -267,7 +267,7 @@ pub struct ArcStringInternerImplInterner {
 impl ArcStringInternerImplInterner {
     pub fn new() -> Self {
         Self {
-            interner: ArcStringInternerImpl::new(), // This will create StringInterner<Sym, RandomState, 0>
+            interner: ArcStringInternerImpl::with_capacity(1024), // This will create StringInterner<Sym, RandomState, 0>
         }
     }
 }


### PR DESCRIPTION
## Summary
- initialize `ArcStringInternerImplInterner` with a starting capacity

## Testing
- `cargo clippy --all-targets --all-features`
- `cargo test` *(fails: `record::should::test_matching_records`)*
- `cargo bench --bench string_interning_benchmark --sample-size 10`

------
https://chatgpt.com/codex/tasks/task_e_68505a058fec832393d5f91801b4a5f3