### PR TITLE
Add InternedStringInterner

### DIFF
--- a/benches/string_interning_benchmark.rs
+++ b/benches/string_interning_benchmark.rs
@@ -1,7 +1,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use drain_flow::intern_benchmark_harness::{
-    ArcStringInternerImplInterner, BucketBackendInterner, BufferBackendInterner, LassoInterner,
-    NoInterningBaseline, SharedStringInterner, StringBackendInterner, StringInternerTrait,
+    ArcStringInternerImplInterner, BucketBackendInterner, BufferBackendInterner,
+    InternedStringInterner, LassoInterner, NoInterningBaseline, SharedStringInterner,
+    StringBackendInterner, StringInternerTrait,
 };
 use lazy_static::lazy_static; // Add this
 use rand::rngs::StdRng; // Add this for a deterministic RNG
@@ -248,6 +249,17 @@ fn string_interning_benchmark(c: &mut Criterion) {
             |(mut interner, lines)| intern_lines(&mut interner, &lines),
         );
     });
+
+    // Add InternedStringInterner benchmark
+    group.bench_function(
+        BenchmarkId::new("InternedStringInterner", "interned-string"),
+        |b| {
+            b.iter_with_setup(
+                || (InternedStringInterner::new(), log_lines.clone()),
+                |(mut interner, lines)| intern_lines(&mut interner, &lines),
+            );
+        },
+    );
 
     // Add ArcStringInternerImplInterner benchmark
     group.bench_function(

--- a/src/drains/differential_drain.rs
+++ b/src/drains/differential_drain.rs
@@ -1258,6 +1258,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_calculate_similarity_len1_and_empty() {
         let msg_tokens_a = vec!["a".to_string()];
         let template_tokens_a = vec![TokenOrWildcard::Token("a".to_string())];

--- a/src/intern_benchmark_harness/mod.rs
+++ b/src/intern_benchmark_harness/mod.rs
@@ -39,9 +39,8 @@ use string_interner::DefaultSymbol;
 use string_interner::StringInterner; // Import RandomState
 
 // New crates for benchmarking
+use interned_string::{IString, Intern};
 use lasso::{Rodeo, Spur};
-// For interned-string v0.2.0, use IString
-// use interned_string::IString as InternedIString; // Alias to avoid confusion if IString is too generic
 // For intern_string v0.1.0, use Intern and InternId
 // use intern_string::{Intern as InternStringIntern, InternId as InternStringInternId};
 // For arc-string-interner
@@ -114,35 +113,32 @@ impl StringInternerTrait for LassoInterner {
     }
 }
 
-// 2. InternedString Interner (using interned_string::IString for v0.2.0) - COMMENTED OUT DUE TO COMPILATION ISSUES
-// pub struct InternedStringInterner {
-//     _marker: std::marker::PhantomData<()>,
-// }
-//
-// impl InternedStringInterner {
-//     pub fn new() -> Self {
-//         Self { _marker: std::marker::PhantomData }
-//     }
-// }
-//
-// impl Default for InternedStringInterner {
-//     fn default() -> Self {
-//         Self::new()
-//     }
-// }
-//
-// impl StringInternerTrait for InternedStringInterner {
-//     type Symbol = InternedIString;
-//
-//     fn intern(&mut self, s: &str) -> Self::Symbol {
-//         // This was failing with E0425: cannot find function `intern` in crate `interned_string`
-//         interned_string::intern(s)
-//     }
-//
-//     fn resolve<'a>(&'a self, symbol: &'a Self::Symbol) -> &'a str {
-//         symbol.as_ref()
-//     }
-// }
+// 2. InternedString Interner (using interned_string::IString)
+pub struct InternedStringInterner;
+
+impl InternedStringInterner {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for InternedStringInterner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl StringInternerTrait for InternedStringInterner {
+    type Symbol = IString;
+
+    fn intern(&mut self, s: &str) -> Self::Symbol {
+        s.intern()
+    }
+
+    fn resolve(&self, symbol: &Self::Symbol) -> String {
+        symbol.as_ref().to_string()
+    }
+}
 
 // 3. intern-string Interner (using intern_string::Intern and InternId for v0.1.0) - COMMENTED OUT DUE TO COMPILATION ISSUES
 // pub struct InternStringImplInterner {


### PR DESCRIPTION
## Summary
- implement `InternedStringInterner` using interned-string crate
- benchmark `InternedStringInterner`
- fix a missing `#[test]` attribute so clippy passes

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test` *(fails: DifferentialDrain: Template mismatch for scenario 1)*

------
https://chatgpt.com/codex/tasks/task_e_685064d9db5483239d30541ab6c37e91