### PR TITLE
Enable bincode for timely dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ string-interner = { version = "0.19.0" }
 tracing = "0.1.36"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
-differential-dataflow = "0.12"
-timely = "0.12"
+differential-dataflow = { version = "0.12", default-features = false }
+timely = { version = "0.12", features = ["bincode"] }
 lasso = "0.7.1"
 interned-string = "*"
 intern_string = "*"


### PR DESCRIPTION
## Summary
- enable `bincode` feature on the `timely` crate
- disable default features on `differential-dataflow`

## Testing
- `cargo fmt --all`
- `cargo clippy` *(fails: `Rc<RefCell<...>>` cannot be sent between threads)*
- `cargo test` *(fails: same Send trait errors)*

------
https://chatgpt.com/codex/tasks/task_e_68506e3a48608323992a4a6fdd1deac5