### PR TITLE
Gate test debug printing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,3 +72,4 @@ harness = false
 
 [features]
 intern_benchmark_harness = []
+verbose-tests = []

--- a/tests/drain_comparison_tests.rs
+++ b/tests/drain_comparison_tests.rs
@@ -15,7 +15,8 @@ fn get_template_string(group: &LogGroup) -> String {
 }
 
 // Helper to print groups for debugging
-#[allow(dead_code)] // Will be used in tests, but good to have for debugging even if not all paths use it.
+#[allow(dead_code)]
+#[cfg(feature = "verbose-tests")]
 fn print_groups_summary(drain_name: &str, groups: &[LogGroup]) {
     println!("\n---- {} ----", drain_name);
     println!("Total groups: {}", groups.len());
@@ -24,16 +25,16 @@ fn print_groups_summary(drain_name: &str, groups: &[LogGroup]) {
             "  Group {}: Count={}, Template='{}', ID={}",
             i,
             group.len(),
-            get_template_string(group), // Use helper
+            get_template_string(group),
             group.id
         );
-        // Optionally print a few samples
-        // for sample in group.examples().iter().take(2) {
-        //     println!("    Sample (ID {}): {}", sample.id, sample.content);
-        // }
     }
     println!("--------------------");
 }
+
+#[allow(dead_code)]
+#[cfg(not(feature = "verbose-tests"))]
+fn print_groups_summary(_drain_name: &str, _groups: &[LogGroup]) {}
 
 #[cfg(test)]
 mod comparative_tests {


### PR DESCRIPTION
## Summary
- gate `print_groups_summary` behind `verbose-tests` feature to silence debug printing by default
- define new optional feature in `Cargo.toml`

## Testing
- `cargo clippy -- -D warnings`
- `cargo test --quiet` *(fails: record::should::test_matching_records)*

------
https://chatgpt.com/codex/tasks/task_e_6850763200a883239fd63db74a417f9c