### PR TITLE
Fix LogGroup new record storage

### DIFF
--- a/src/drains/differential_drain.rs
+++ b/src/drains/differential_drain.rs
@@ -766,9 +766,9 @@ mod tests {
         assert_eq!(log_groups.len(), 1);
         let group = &log_groups[0];
         assert_eq!(group.id, cluster_id);
-        assert_eq!(group.len(), 1);
+        assert_eq!(group.len(), 2);
         assert_eq!(group.base_record().to_string(), expected_tokens.join(" "));
-        assert_eq!(group.examples().len(), 1);
+        assert_eq!(group.examples().len(), 2);
         assert_eq!(group.examples()[0].to_string(), expected_tokens.join(" "));
     }
 
@@ -789,9 +789,9 @@ mod tests {
         assert_eq!(log_groups.len(), 1);
         let group = &log_groups[0];
         assert_eq!(group.id, cluster_id);
-        assert_eq!(group.len(), 2);
+        assert_eq!(group.len(), 3);
         assert_eq!(group.base_record().to_string(), "<*> log for multi-cluster");
-        assert_eq!(group.examples().len(), 2);
+        assert_eq!(group.examples().len(), 3);
         assert!(group
             .examples()
             .iter()
@@ -816,16 +816,16 @@ mod tests {
         assert_eq!(log_groups.len(), 1);
         let group = &log_groups[0];
         assert_eq!(group.id, cluster_id);
-        assert_eq!(group.len(), 2);
+        assert_eq!(group.len(), 3);
         assert_eq!(group.base_record().to_string(), "Repeated log line");
-        assert_eq!(group.examples().len(), 2);
+        assert_eq!(group.examples().len(), 3);
         assert_eq!(
             group
                 .examples()
                 .iter()
                 .filter(|r| r.to_string() == "Repeated log line")
                 .count(),
-            2
+            3
         );
     }
 

--- a/src/log_group/mod.rs
+++ b/src/log_group/mod.rs
@@ -38,10 +38,11 @@ impl fmt::Display for Wildcard {
 impl LogGroup {
     #[instrument(level = "trace", skip(event))]
     pub fn new(event: Record) -> Self {
+        let id = event.uid;
         Self {
-            id: event.uid,
+            id,
+            examples: vec![event.clone()],
             event,
-            examples: vec![],
             variables: HashMap::new(),
         }
     }
@@ -107,7 +108,7 @@ impl LogGroup {
         }
     }
 
-    /// Number of examples this [LogGroup] contains
+    /// Total number of records stored in this [LogGroup]
     #[instrument(level = "trace", skip_all)]
     pub fn len(&self) -> usize {
         self.examples.len()

--- a/src/query.rs
+++ b/src/query.rs
@@ -692,8 +692,7 @@ mod tests {
 
             for group in &log_groups_vec { // Use log_groups_vec here
                 if selected_group_ids_set.contains(&group.id) {
-                    let mut records_to_check = group.examples().clone();
-                    records_to_check.push(group.base_record().clone());
+                    let records_to_check = group.examples().clone();
                     for original_record in records_to_check {
                         let matches_filter = query.filter.as_ref().is_none_or(|f| original_record.to_string().contains(&f.contains));
                         if matches_filter {

--- a/tests/drain_comparison_tests.rs
+++ b/tests/drain_comparison_tests.rs
@@ -89,7 +89,7 @@ mod comparative_tests {
             );
             assert_eq!(
                 dd_groups[0].len(),
-                3,
+                4,
                 "DifferentialDrain: Count mismatch for scenario 1"
             );
         }
@@ -181,7 +181,7 @@ mod comparative_tests {
             );
             assert_eq!(
                 dd_groups[0].len(),
-                5,
+                6,
                 "DifferentialDrain: Count mismatch for scenario 2"
             );
         }


### PR DESCRIPTION
## Summary
- store base event in LogGroup examples
- update len() to count all records
- adjust DifferentialDrain and comparison tests for new counting
- tweak property test helper not to double count base record

## Testing
- `cargo clippy -- -D warnings`
- `cargo test -- --nocapture` *(fails: record::should::test_matching_records)*

------
https://chatgpt.com/codex/tasks/task_e_6850764566508323a7f1a40b8bc7f857