### PR TITLE
Remove legacy Drain logic

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,11 @@ extern crate enum_derive;
 
 pub mod core_structures;
 pub mod drain_parser;
-pub mod drains;
-pub mod runtime;
+mod drains;
 pub mod intern_benchmark_harness;
-pub mod log_group;
+mod log_group;
 pub mod record;
+pub mod runtime;
 
 /// # Log Querying
 ///

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -1,33 +1,25 @@
-use crate::core_structures::{LogTemplate, ParameterValue, RawLogEntry, TemplateToken};
+use crate::core_structures::{ParameterValue, RawLogEntry, TemplateToken};
 use crate::drain_parser::DrainParser; // From Step 3
 use chrono::{DateTime, Utc};
 use differential_dataflow::input::InputSession;
 use differential_dataflow::operators::Consolidate;
 use differential_dataflow::Collection;
-use std::collections::HashMap;
 use std::sync::{mpsc, Arc, Mutex};
 #[allow(unused_imports)]
 use timely::dataflow::operators::Inspect;
-use uuid::Uuid; // Added for templates_mirror
+use uuid::Uuid;
 
 pub struct LogProcessingEngine {
     worker_thread_handle: Option<std::thread::JoinHandle<()>>, // To keep the worker alive
     log_sender: mpsc::Sender<Option<RawLogEntry>>, // Channel for sending logs to the worker
-    // Collections that can be inspected (will require more sophisticated query mechanisms later)
-    // These are placeholders to show intent; actual querying will be more complex.
-    // For now, we might not store Arc<Mutex<Collection>> directly but build them in the dataflow.
-    // The ability to query them will come from dataflow probes or specific arrangements.
-
-    // We need a way to get templates out for the Drain API (collect_log_groups)
-    // This might be a shared map updated by a probe on the templates collection.
-    templates_mirror: Arc<Mutex<HashMap<Uuid, LogTemplate>>>,
+                                                   // Collections that can be inspected (will require more sophisticated query mechanisms later)
+                                                   // These are placeholders to show intent; actual querying will be more complex.
+                                                   // For now, we might not store Arc<Mutex<Collection>> directly but build them in the dataflow.
+                                                   // The ability to query them will come from dataflow probes or specific arrangements.
 }
 
 impl LogProcessingEngine {
     pub fn new() -> Self {
-        let templates_mirror_arc = Arc::new(Mutex::new(HashMap::new()));
-        let templates_mirror_handle = templates_mirror_arc.clone();
-
         let (sender, receiver) = mpsc::channel::<Option<RawLogEntry>>();
         let receiver = Arc::new(Mutex::new(receiver));
         let receiver_handle = receiver.clone();
@@ -36,7 +28,6 @@ impl LogProcessingEngine {
             // Initialize Timely worker with a single worker thread.
             timely::execute::execute_from_args(std::iter::empty::<String>(), move |worker| {
                 let mut drain_parser = DrainParser::new(0.6, 4); // Default params for now
-                let templates_mirror_handle_clone_for_dataflow = templates_mirror_handle.clone();
                 let mut input_session: InputSession<usize, RawLogEntry, isize> =
                     InputSession::new();
 
@@ -129,32 +120,12 @@ impl LogProcessingEngine {
                         log_templates_data;
 
                     // Consolidate to ensure templates are unique if multiple identical templates are emitted.
-                    // Then, use a probe to update the shared templates_mirror.
-                    let templates_mirror_handle_for_inspect =
-                        templates_mirror_handle_clone_for_dataflow.clone();
-                    log_templates.consolidate().inspect(move |x| {
-                        // x is ((data, time, diff)) where data is (Uuid, Vec<TemplateToken>)
-                        // Update the shared map for external access
-                        let template_id = (x.0).0;
-                        let template_tokens = (x.0).1.clone();
-                        let diff = x.2;
-
-                        let mut mirror = templates_mirror_handle_for_inspect.lock().unwrap();
-                        if diff > 0 {
-                            mirror.insert(
-                                template_id,
-                                LogTemplate {
-                                    id: template_id,
-                                    tokens: template_tokens,
-                                },
-                            );
-                        } else {
-                            // Handle retraction if necessary, though simple DRAIN might not retract templates often.
-                            // For now, positive diffs add/update.
-                        }
+                    log_templates.consolidate().inspect(|x| {
                         println!(
                             "Log Template (Timestamp: {:?}, ID: {}, Diff: {:?})",
-                            x.1, template_id, diff
+                            x.1,
+                            (x.0).0,
+                            x.2
                         );
                     });
                 });
@@ -180,23 +151,12 @@ impl LogProcessingEngine {
         Self {
             worker_thread_handle: Some(worker_thread_handle),
             log_sender: sender,
-            templates_mirror: templates_mirror_arc,
         }
     }
 
     pub fn ingest_raw_log(&self, raw_log: RawLogEntry) {
         // Send the log entry to the worker thread. Ignore errors during shutdown.
         let _ = self.log_sender.send(Some(raw_log));
-    }
-
-    // Placeholder for getting templates (e.g., for Drain::collect_log_groups)
-    pub fn get_all_templates(&self) -> Vec<LogTemplate> {
-        self.templates_mirror
-            .lock()
-            .unwrap()
-            .values()
-            .cloned()
-            .collect()
     }
 
     // Placeholder for direct query (will be replaced by proper dataflow queries)


### PR DESCRIPTION
## Summary
- stop exporting legacy drains and log group modules
- drop templates_mirror from `LogProcessingEngine`
- trim runtime dataflow to no longer mirror templates

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: unused imports and dead code in existing sources)*
- `cargo test --all-features` *(fails: compile errors in integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_6850abe45ddc832389c99490d3a007db