### PR TITLE
Implement logical time in runtime

### DIFF
--- a/src/drain_parser.rs
+++ b/src/drain_parser.rs
@@ -349,6 +349,7 @@ impl DrainParser {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::useless_vec)]
     use super::*;
     use crate::core_structures::{ParameterValue, RawLogEntry, TemplateToken};
     use chrono::Utc;

--- a/src/drains/differential_drain.rs
+++ b/src/drains/differential_drain.rs
@@ -1258,6 +1258,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn test_calculate_similarity_len1_and_empty() {
         let msg_tokens_a = vec!["a".to_string()];
         let template_tokens_a = vec![TokenOrWildcard::Token("a".to_string())];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,9 +15,9 @@ extern crate enum_derive;
 
 pub mod core_structures;
 pub mod drain_parser;
-mod drains;
+pub mod drains;
 pub mod intern_benchmark_harness;
-mod log_group;
+pub mod log_group;
 pub mod record;
 pub mod runtime;
 

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -9,18 +9,25 @@ use std::sync::{mpsc, Arc, Mutex};
 use timely::dataflow::operators::Inspect;
 use uuid::Uuid;
 
+pub enum WorkerMessage {
+    Log(usize, RawLogEntry),
+    AdvanceTo(usize),
+    Terminate,
+}
+
 pub struct LogProcessingEngine {
     worker_thread_handle: Option<std::thread::JoinHandle<()>>, // To keep the worker alive
-    log_sender: mpsc::Sender<Option<RawLogEntry>>, // Channel for sending logs to the worker
-                                                   // Collections that can be inspected (will require more sophisticated query mechanisms later)
-                                                   // These are placeholders to show intent; actual querying will be more complex.
-                                                   // For now, we might not store Arc<Mutex<Collection>> directly but build them in the dataflow.
-                                                   // The ability to query them will come from dataflow probes or specific arrangements.
+    log_sender: mpsc::Sender<WorkerMessage>, // Channel for sending logs to the worker
+    current_time: usize,
+    // Collections that can be inspected (will require more sophisticated query mechanisms later)
+    // These are placeholders to show intent; actual querying will be more complex.
+    // For now, we might not store Arc<Mutex<Collection>> directly but build them in the dataflow.
+    // The ability to query them will come from dataflow probes or specific arrangements.
 }
 
 impl LogProcessingEngine {
     pub fn new() -> Self {
-        let (sender, receiver) = mpsc::channel::<Option<RawLogEntry>>();
+        let (sender, receiver) = mpsc::channel::<WorkerMessage>();
         let receiver = Arc::new(Mutex::new(receiver));
         let receiver_handle = receiver.clone();
 
@@ -130,18 +137,21 @@ impl LogProcessingEngine {
                     });
                 });
 
-                let mut time = 0usize;
                 loop {
                     let msg = receiver_handle.lock().unwrap().recv();
                     match msg {
-                        Ok(Some(raw_log)) => {
-                            input_session.update_at(raw_log, time, 1);
-                            time += 1;
-                            input_session.advance_to(time);
+                        Ok(WorkerMessage::Log(ts, raw_log)) => {
+                            input_session.update_at(raw_log, ts, 1);
+                            input_session.advance_to(ts + 1);
                             input_session.flush();
                             worker.step();
                         }
-                        Ok(None) | Err(_) => break,
+                        Ok(WorkerMessage::AdvanceTo(t)) => {
+                            input_session.advance_to(t);
+                            input_session.flush();
+                            worker.step();
+                        }
+                        Ok(WorkerMessage::Terminate) | Err(_) => break,
                     }
                 }
             })
@@ -151,12 +161,23 @@ impl LogProcessingEngine {
         Self {
             worker_thread_handle: Some(worker_thread_handle),
             log_sender: sender,
+            current_time: 0,
         }
     }
 
-    pub fn ingest_raw_log(&self, raw_log: RawLogEntry) {
-        // Send the log entry to the worker thread. Ignore errors during shutdown.
-        let _ = self.log_sender.send(Some(raw_log));
+    pub fn ingest_raw_log(&mut self, raw_log: RawLogEntry) {
+        let time = self.current_time;
+        self.current_time += 1;
+        // Send the log entry to the worker thread with its logical time.
+        let _ = self.log_sender.send(WorkerMessage::Log(time, raw_log));
+    }
+
+    /// Manually advance the logical clock without ingesting a log entry.
+    pub fn advance_time(&mut self) {
+        self.current_time += 1;
+        let _ = self
+            .log_sender
+            .send(WorkerMessage::AdvanceTo(self.current_time));
     }
 
     // Placeholder for direct query (will be replaced by proper dataflow queries)
@@ -175,7 +196,7 @@ impl Default for LogProcessingEngine {
 impl Drop for LogProcessingEngine {
     fn drop(&mut self) {
         // Signal the worker thread to finish and join it.
-        let _ = self.log_sender.send(None);
+        let _ = self.log_sender.send(WorkerMessage::Terminate);
         if let Some(handle) = self.worker_thread_handle.take() {
             handle.join().expect("Failed to join timely worker thread.");
         }


### PR DESCRIPTION
## Summary
- track current logical time in `LogProcessingEngine`
- send timestamps to worker thread via `WorkerMessage`
- expose `advance_time` method
- make `drains` and `log_group` modules public
- silence clippy lints in parser tests

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`


------
https://chatgpt.com/codex/tasks/task_e_6850bbe7d0a88323a39a2af036e893fc