### PR TITLE
feat: Define foundational data structures for Differential Drain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ rust-version="1.78.0"
 [dependencies]
 anyhow = "1.0.63"
 arc-string-interner = "0.3.0-alpha2"
-chrono = "0.4.22"
+chrono = { version = "0.4.22", features = ["serde"] }
 custom_derive = "0.1.7"
 derive_more = { version="2.0.0", features=["full"]}
 enum_derive = "0.1.7"
@@ -28,8 +28,9 @@ tracing = "0.1.36"
 serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 differential-dataflow = "0.12"
-timely = "0.12"
-lasso = "0.7.1"
+timely = { version = "0.12.0", features = ["bincode"] }
+lasso = { version = "0.7.1", features = ["serde"] }
+bincode = "1.3.3"
 interned-string = "*"
 intern_string = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ serde = { version = "1.0.144", features = ["derive"] }
 serde_json = "1.0.85"
 differential-dataflow = "0.12"
 timely = { version = "0.12.0", features = ["bincode"] }
-lasso = { version = "0.7.1", features = ["serde"] }
+lasso = { version = "0.7.1", features = ["serialize"] }
 bincode = "1.3.3"
 interned-string = "*"
 intern_string = "*"

--- a/src/drains/dd_types.rs
+++ b/src/drains/dd_types.rs
@@ -1,0 +1,35 @@
+use chrono::{DateTime, Utc};
+use lasso::Spur;
+use serde::{Deserialize, Serialize};
+use timely::order::Product;
+use uuid::Uuid;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct RawLog {
+    pub content: String,
+    // Original timestamp can be part of the dataflow timestamp
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct TokenizedLog {
+    pub original_id: Uuid, // A unique ID for traceability
+    pub tokens: Vec<Spur>,
+    pub token_count: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct LogTemplate {
+    pub template_id: Uuid,
+    // A mix of concrete tokens and a special wildcard token
+    pub template_tokens: Vec<Spur>,
+    pub token_count: usize,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct LogCluster {
+    pub template_id: Uuid,
+    pub template_tokens: Vec<Spur>,
+    pub event_count: u64,
+    // Include a few sample raw log lines for context
+    pub samples: Vec<String>,
+}

--- a/src/drains/mod.rs
+++ b/src/drains/mod.rs
@@ -1,4 +1,3 @@
-pub mod dd_types;
 //! # Log Processing Drains
 //!
 //! This module provides mechanisms for processing, clustering, and managing log data.
@@ -9,6 +8,7 @@ pub mod dd_types;
 //!
 //! The primary purpose of this module is to abstract the specifics of log processing,
 //! allowing other parts of the system to interact with log data through a consistent API.
+pub mod dd_types;
 
 // Copyright Nicholas Harring. All rights reserved.
 //

--- a/src/drains/mod.rs
+++ b/src/drains/mod.rs
@@ -1,3 +1,4 @@
+pub mod dd_types;
 //! # Log Processing Drains
 //!
 //! This module provides mechanisms for processing, clustering, and managing log data.


### PR DESCRIPTION
This commit introduces the foundational data structures for the Differential Drain log clustering engine. These structures are defined in the new module `src/drains/dd_types.rs`.

The following structures have been added:
- `RawLog`: Represents a single, unprocessed log line.
- `TokenizedLog`: Represents a log after tokenization, using interned strings.
- `LogTemplate`: Represents a generalized log cluster.
- `LogCluster`: Represents the output, linking a template to its statistics.

All string-like data that will be processed in collections (log tokens, etc.) will be interned using the `lasso` crate. The symbol type is `lasso::Spur`. All data entering the dataflow will be associated with a logical timestamp of type `timely::order::Product<chrono::DateTime<Utc>, u64>`.

The `Cargo.toml` file has been updated to:
- Enable the `serde` feature for the `lasso` and `chrono` dependencies.
- Update the `timely` dependency to version `0.12.0` and enable its `bincode` feature.
- Add `bincode` as a new dependency.

The new `dd_types` module has been registered in `src/drains/mod.rs`.